### PR TITLE
Don't check for access before updating package from xml.

### DIFF
--- a/ckanext/switzerland/logic.py
+++ b/ckanext/switzerland/logic.py
@@ -292,8 +292,6 @@ def _create_or_update_dataset(dataset):
     user = tk.get_action('get_site_user')({'ignore_auth': True}, {})
     context.update({'user': user['name']})
 
-    tk.check_access('package_show', {})
-
     harvester = SwissDCATRDFHarvester()
     name = harvester._gen_new_name(dataset['title'])
 


### PR DESCRIPTION
Apparently this check is not needed. It was also causing an error because, unless you are a sysadmin, the check-access method requires the dataset id. We don't have an id or name for the dataset at this point (it's created a couple of lines down).