### PR TITLE
Fix html for dataset page.

### DIFF
--- a/ckanext/switzerland/templates/package/snippets/additional_info.html
+++ b/ckanext/switzerland/templates/package/snippets/additional_info.html
@@ -1,4 +1,4 @@
-<section class="container additional-info">
+<section class="additional-info">
   <div class="row">
     <div class="col-xs-12">
       <h2>{{ _('Additional information') }}</h2>


### PR DESCRIPTION
The additional-info section is inside a container (which sets the width for the whole page content), so it should not also be a container itself.