### PR TITLE
Fix a handful of display issues

### DIFF
--- a/ckanext/switzerland/helpers/frontend_helpers.py
+++ b/ckanext/switzerland/helpers/frontend_helpers.py
@@ -151,7 +151,8 @@ def get_terms_of_use_url(terms_of_use):
 
 
 def get_dataset_terms_of_use(pkg):
-    rights = logic.get_action('ogdch_dataset_terms_of_use')({}, {'id': pkg})
+    rights = logic.get_action('ogdch_dataset_terms_of_use')(
+        {}, {'id': pkg['id']})
     return rights['dataset_rights']
 
 

--- a/ckanext/switzerland/templates/group/read_base.html
+++ b/ckanext/switzerland/templates/group/read_base.html
@@ -17,6 +17,11 @@
   {% endblock %}
 {% endblock %}
 
+{% block content_primary_nav %}
+  {{ h.build_nav_icon(group_type + '_read', _('Datasets'), id=c.group_dict.name) }}
+  {{ h.build_nav_icon(group_type + '_about', _('About'), id=c.group_dict.name) }}
+{% endblock %}
+
 {% block secondary_content %}
   {% snippet "group/snippets/info.html", group=group, show_nums=false, schema=schema, display_name=display_name %}
 {% endblock %}

--- a/ckanext/switzerland/templates/header.html
+++ b/ckanext/switzerland/templates/header.html
@@ -9,7 +9,7 @@
        </a>
      </li>
      <li class="{{ h.ogdch_template_helper_get_active_class(request.url, 'harvest') }}">
-       {{ h.nav_link(_('Harvest Sources'), named_route='{0}_search'.format('harvest')) }}
+       {{ h.nav_link(_('Harvest Sources'), named_route='harvest_search') }}
      </li>
      <li class="{{ h.ogdch_template_helper_get_active_class(request.url, 'dataset') }}">
          {{ h.nav_link(_('Datasets'), named_route='search') }}

--- a/ckanext/switzerland/templates/organization/read_base.html
+++ b/ckanext/switzerland/templates/organization/read_base.html
@@ -26,3 +26,8 @@
     controller='organization', action='read', id=c.group_dict.name %}
   </li>
 {% endblock %}
+
+{% block content_primary_nav %}
+  {{ h.build_nav_icon(group_type + '_read', _('Datasets'), id=c.group_dict.name) }}
+  {{ h.build_nav_icon(group_type + '_about', _('About'), id=c.group_dict.name) }}
+{% endblock %}

--- a/ckanext/switzerland/templates/package/read_base.html
+++ b/ckanext/switzerland/templates/package/read_base.html
@@ -3,6 +3,5 @@
 {% block content_primary_nav %}
   {{ h.build_nav_icon('dataset_read', _('Dataset'), id=pkg.name) }}
   {{ h.build_nav_icon('dataset_groups', _('Categories'), id=pkg.name, ckan_icon='folder') }}
-  {{ h.build_nav_icon('dataset_activity', _('Activity Stream'), id=pkg.name) }}
   {{ h.build_nav_icon('dataset_showcase_list', _('Showcases'), id=pkg.name) }}
 {% endblock %}

--- a/ckanext/switzerland/templates/scheming/display_snippets/fluent_tags.html
+++ b/ckanext/switzerland/templates/scheming/display_snippets/fluent_tags.html
@@ -2,9 +2,10 @@
 {% block tag_list %}
   <ul class="tag-list">
     {% for tag in data[field.field_name] %}
+      {% set tag_dict = {'keywords_' + h.lang(): tag} %}
       <li>
-        <a class="{% block tag_list_item_class %}tag{% endblock %}" href="{%
-          url_for controller='package', action='search', tags=tag %}">{{
+        <a class="{% block tag_list_item_class %}tag{% endblock %}" href="{{
+          h.url_for(controller='package', action='search', **tag_dict) }}">{{
             h.truncate(tag, 22) }}</a>
       </li>
     {% endfor %}

--- a/ckanext/switzerland/templates/scheming/package/resource_read.html
+++ b/ckanext/switzerland/templates/scheming/package/resource_read.html
@@ -5,7 +5,6 @@
     'description',
     'notes',
     'display_name',
-    'rights',
     'license',
     'coverage',
     'media_type',

--- a/ckanext/switzerland/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/switzerland/templates/scheming/package/snippets/additional_info.html
@@ -30,6 +30,8 @@
       </dd>
     {%- endif -%}
   {%- endfor -%}
+  <dt class="dataset-label">{{ _('Terms of use') }}</dt>
+  <dd class="dataset-details">{{ h.get_dataset_terms_of_use(pkg_dict) }}</dd>
   <dt class="dataset-label">{{ _('Metadata Access') }}</dt>
   <dd class="dataset-details">
       <a href="/api/3/action/package_show?id={{ pkg_dict.name }}" class="btn btn-primary btn-xs" role="button" target="_blank" >

--- a/ckanext/switzerland/templates/snippets/search_form.html
+++ b/ckanext/switzerland/templates/snippets/search_form.html
@@ -25,6 +25,8 @@
   <div class="reset-search">
     {% if c.group_dict.name %}
       <a href="{{ h.url_for(controller=c.controller, action=c.action, id=c.group_dict.name) }}"><i class="fa fa-times-circle" aria-hidden="true"></i> {{ _('Reset search') }}</a>
+    {% elif c.dataset_type == 'harvest' %}
+      <a href="{{ h.url_for('harvest_search') }}"><i class="fa fa-times-circle" aria-hidden="true"></i> {{ _('Reset search') }}</a>
     {% else %}
       <a href="{{ h.url_for(controller=c.controller, action=c.action) }}"><i class="fa fa-times-circle" aria-hidden="true"></i> {{ _('Reset search') }}</a>
     {% endif %}

--- a/ckanext/switzerland/templates/user/dashboard.html
+++ b/ckanext/switzerland/templates/user/dashboard.html
@@ -8,8 +8,7 @@
           {% link_for _('Edit settings'), named_route='user.edit', id=user.name, class_='btn btn-default', icon='cog' %}
         </div>
         <ul class="nav nav-tabs">
-          {{ h.build_nav_icon('dashboard.index', _('News feed')) }}
-          {{ h.build_nav_icon('dashboard.datasets', _('My Datasets')) }}
+          {{ h.build_nav_icon('dashboard.index', _('My Datasets')) }}
           {{ h.build_nav_icon('dashboard.organizations', _('My Organizations')) }}
         </ul>
       </header>
@@ -17,22 +16,25 @@
     <div class="module-content">
       {% if self.page_primary_action() | trim %}
         <div class="page_primary_action">
-          {% block page_primary_action %}{% endblock %}
+          {% block page_primary_action %}
+            {% if h.check_access('package_create') %}
+              {% snippet 'snippets/add_dataset.html' %}
+            {% endif %}
+          {% endblock %}
         </div>
       {% endif %}
       {% block primary_content_inner %}
-        <div data-module="dashboard">
-          {% snippet 'user/snippets/followee_dropdown.html', context=dashboard_activity_stream_context, followees=followee_list %}
-          <h2 class="page-heading">
-            {% block page_heading %}
-              {{ _('News feed') }}
-            {% endblock %}
-            <small>{{ _("Activity from items that I'm following") }}</small>
-          </h2>
-          {% block activity_stream %}
-            {{ dashboard_activity_stream|safe }}
-          {% endblock %}
-        </div>
+        <h2 class="hide-heading">{{ _('My Datasets') }}</h2>
+        {% if user_dict.datasets %}
+          {% snippet 'snippets/package_list.html', packages=user_dict.datasets %}
+        {% else %}
+          <p class="empty">
+            {{ _('You haven\'t created any datasets.') }}
+            {% if h.check_access('package_create') %}
+              {% link_for _('Create one now?'), controller='package', action='new' %}
+            {% endif %}
+          </p>
+        {% endif %}
       {% endblock %}
     </div>
   </article>

--- a/ckanext/switzerland/templates/user/read_base.html
+++ b/ckanext/switzerland/templates/user/read_base.html
@@ -3,5 +3,4 @@
 {% block content_primary_nav %}
   {{ h.build_nav_icon('user.read', _('Datasets'), id=user.name) }}
   {{ h.build_nav_icon('organization_list', _('Organizations'), id=user.name) }}
-  {{ h.build_nav_icon('user.activity', _('Activity Stream'), id=user.name) }}
 {% endblock %}


### PR DESCRIPTION
- Fix tag links on dataset page going to `/dataset?tags=foo` instead of language-specific `/dataset?keyword_de=foo`.
- Display terms of use on resource and dataset pages.
- Fix the `Reset search` link on the harvester search box.
- Remove `Activity stream` tabs on user, dataset, group and organization pages.