### PR TITLE
Don't treat requests from JS modules as API requests.

### DIFF
--- a/ckanext/switzerland/helpers/request_utils.py
+++ b/ckanext/switzerland/helpers/request_utils.py
@@ -20,7 +20,6 @@ def request_is_api_request():
         # Do not change the resulting dict for API requests
         path = tk.request.path
         if any([
-            path.startswith('/api'),
             path.endswith('.xml'),
             path.endswith('.rdf'),
             path.endswith('.n3'),
@@ -28,6 +27,11 @@ def request_is_api_request():
             path.endswith('.jsonld'),
 
         ]):
+            return True
+        if path.startswith('/api') and not path.startswith('/api/action'):
+            # The API client for CKAN's JS modules uses a path starting
+            # /api/action, i.e. without a version number. All other API calls
+            # should include a version number.
             return True
     except TypeError:
         # we get here if there is no request (i.e. on the command line)


### PR DESCRIPTION
This means we will not transform data that's retrieved from the database by these calls the way we would transform data requested by external API calls.