### PR TITLE
Don't render markdown in descriptions

### DIFF
--- a/ckanext/switzerland/helpers/plugin_utils.py
+++ b/ckanext/switzerland/helpers/plugin_utils.py
@@ -6,7 +6,6 @@ import re
 import datetime
 from ckan import logic
 import ckan.plugins.toolkit as toolkit
-from ckan.lib.helpers import render_markdown
 from ckan.lib.munge import munge_title_to_name
 import ckanext.switzerland.helpers.localize_utils as ogdch_loc_utils
 import ckanext.switzerland.helpers.terms_of_use_utils as ogdch_term_utils
@@ -211,10 +210,6 @@ def ogdch_prepare_pkg_dict_for_api(pkg_dict):
 
     if ogdch_request_utils.request_is_api_request():
         _transform_package_dates(pkg_dict)
-
-        pkg_dict['description'] = {
-            k: render_markdown(pkg_dict['description'][k])
-            for k in pkg_dict['description']}
 
     return pkg_dict
 

--- a/ckanext/switzerland/plugins.py
+++ b/ckanext/switzerland/plugins.py
@@ -1,7 +1,6 @@
 # coding=UTF-8
 
 from ckan.common import OrderedDict
-from ckan.lib.helpers import render_markdown
 from ckanext.showcase.plugin import ShowcasePlugin
 import ckanext.switzerland.helpers.validators as ogdch_validators
 from ckanext.switzerland import logic as ogdch_logic
@@ -307,9 +306,6 @@ class OgdchResourcePlugin(plugins.SingletonPlugin, OgdchMixin):
             resource=res_dict, format_mapping=self.format_mapping)
 
         if ogdch_request_utils.request_is_api_request():
-            res_dict['description'] = {
-                k: render_markdown(res_dict['description'][k])
-                for k in res_dict['description']}
             return res_dict
 
         request_lang = ogdch_request_utils.get_request_language()


### PR DESCRIPTION
This led to outputting HTML in resource and package descriptions everywhere, including in ttl and xml export. The frontend can render the markdown OK so let's stick with that on our side.