### PR TITLE
add attribute coverage on resource detail page

### DIFF
--- a/ckanext/switzerland/templates/scheming/package/resource_read.html
+++ b/ckanext/switzerland/templates/scheming/package/resource_read.html
@@ -6,7 +6,6 @@
     'notes',
     'display_name',
     'license',
-    'coverage',
     'media_type',
     ] -%}
 {%- set schema = h.scheming_get_dataset_schema(dataset_type) -%}


### PR DESCRIPTION
I just display the coverage attribute as it is: it can be a date or something else: it has not the usual dateformat, but I decided against transforming it in any way: just displaying it the the way we get it, which is in the format YYYY-MM-DD so far.