### PR TITLE
Add the ignore_missing for the tracking

### DIFF
--- a/ckanext/switzerland/plugins.py
+++ b/ckanext/switzerland/plugins.py
@@ -466,6 +466,7 @@ class OgdchShowcasePlugin(ShowcasePlugin):
         schema = super(OgdchShowcasePlugin, self).show_package_schema()
         schema.update(
             {
+                "tracking_summary": [toolkit.get_validator("ignore_missing")],
                 "showcase_type": [
                     toolkit.get_converter("convert_from_extras"),
                     toolkit.get_validator("ignore_missing"),


### PR DESCRIPTION
The above PR will fix the issue for the showcase internal server error which is due to the empty `tracking_summary` field and similar issue was there (https://github.com/ckan/ckan/issues/1343) but not exact same.

