### PR TITLE
Remove erroneously-added translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,26 @@ CKAN extension for DCAT-AP Switzerland, templates and different plugins for [ope
 
 ## Update translations
 
-To generate a new ckanext-switzerland.pot file inside the Docker container,
-use the following command:
+To generate an updated ckanext-switzerland.pot file inside the Docker 
+container, use the following commands:
 
     docker-compose exec ckan bash
     source /usr/lib/ckan/venv/bin/activate
     cd /usr/lib/ckanext/ckanext-switzerland-ng/
     python setup.py extract_messages
 
-This will generate the `pot` files
-Then update the `po` files with:
+Copy any new strings that you want to translate from the new
+`ckanext-switzerland.pot` into the `ckanext-switzerland.po` file for each
+language, and add the translations.
 
-    python setup.py update_catalog -l de
-
-Now the translations can be filled in. After that compile the po files into mo files:
+After that compile the po files into mo files:
 
     python setup.py compile_catalog
+
+Log out of the ckan container (ctrl+D) and restart it for the new translations
+to be used:
+
+    docker-compose restart ckan
 
 ## Installation
 

--- a/ckanext/switzerland/i18n/de/LC_MESSAGES/ckanext-switzerland.po
+++ b/ckanext/switzerland/i18n/de/LC_MESSAGES/ckanext-switzerland.po
@@ -104,21 +104,6 @@ msgstr "Art des Inhalts"
 msgid "Groups"
 msgstr "Kategorien"
 
-#: ckanext/switzerland/controllers/group.py:111
-#: ckanext/switzerland/controllers/organization.py:119
-#: ckanext/switzerland/templates/showcase/new_package_form.html:25
-msgid "Tags"
-msgstr ""
-
-#: ckanext/switzerland/controllers/group.py:113
-#: ckanext/switzerland/controllers/organization.py:121
-msgid "Licenses"
-msgstr ""
-
-#: ckanext/switzerland/controllers/organization.py:227
-msgid "Not authorized to see this page"
-msgstr ""
-
 #: ckanext/switzerland/controllers/organization.py:288
 msgid "Only POST is available"
 msgstr ""
@@ -126,35 +111,6 @@ msgstr ""
 #: ckanext/switzerland/controllers/perma.py:28
 msgid "Dataset not found"
 msgstr "Datensatz nicht gefunden"
-
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:60
-msgid "file"
-msgstr ""
-
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:68
-msgid "Please select the file to upload again"
-msgstr ""
-
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:72
-#, fuzzy
-msgid "Remove"
-msgstr "Vorschau"
-
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:87
-msgid "Upload a file on your computer"
-msgstr ""
-
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:109
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:178
-#: ckanext/switzerland/templates/showcase/new_package_form.html:16
-msgid "URL"
-msgstr ""
-
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:118
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:209
-#: ckanext/switzerland/templates/macros/form.html:16
-msgid "File"
-msgstr ""
 
 #: ckanext/switzerland/helpers/backend_helpers.py:179
 #: ckanext/switzerland/helpers/frontend_helpers.py:110
@@ -175,64 +131,6 @@ msgstr "Gemeinde"
 #: ckanext/switzerland/helpers/frontend_helpers.py:113
 msgid "Other"
 msgstr "Weitere"
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:33
-msgid "* Non-commercial Allowed / Commercial Allowed / Reference Not Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:35
-msgid ""
-"* Non-commercial Allowed / Commercial With Permission Allowed / Reference"
-" Not Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:37
-msgid ""
-"* Non-commercial Allowed / Commercial With Permission Allowed / Reference"
-" Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:39
-msgid "* Non-commercial Allowed / Commercial Allowed / Reference Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:41
-msgid "Non-commercial Allowed / Commercial Not Allowed / Reference Not Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:43
-msgid "Non-commercial Allowed / Commercial Not Allowed / Reference Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:45
-msgid ""
-"Non-commercial Not Allowed / Commercial Not Allowed / Reference Not "
-"Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:47
-msgid "Non-commercial Not Allowed / Commercial Not Allowed / Reference Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:49
-msgid "Non-commercial Not Allowed / Commercial Allowed / Reference Not Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:51
-msgid "Non-commercial Not Allowed / Commercial Allowed / Reference Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:53
-msgid ""
-"Non-commercial Not Allowed / Commercial With Permission Allowed / "
-"Reference Not Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:55
-msgid ""
-"Non-commercial Not Allowed / Commercial With Permission Allowed / "
-"Reference Required"
-msgstr ""
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:82
 msgid "Irregular"
@@ -394,17 +292,6 @@ msgstr ""
 msgid "unexpected choice \"%s\""
 msgstr ""
 
-#: ckanext/switzerland/templates/header.html:9
-#: ckanext/switzerland/templates/user/list.html:12
-msgid "Users"
-msgstr ""
-
-#: ckanext/switzerland/templates/header.html:15
-#: ckanext/switzerland/templates/source/base.html:6
-#: ckanext/switzerland/templates/source/base.html:9
-msgid "Harvest Sources"
-msgstr ""
-
 #: ckanext/switzerland/templates/group/read_base.html:21
 #: ckanext/switzerland/templates/header.html:19
 #: ckanext/switzerland/templates/organization/bulk_process.html:20
@@ -420,76 +307,9 @@ msgstr "Datensätze"
 msgid "Showcases"
 msgstr "Showcases"
 
-#: ckanext/switzerland/templates/admin/trash.html:20
-msgid "Purge"
-msgstr ""
-
-#: ckanext/switzerland/templates/admin/trash.html:29
-msgid "Trash"
-msgstr ""
-
-#: ckanext/switzerland/templates/admin/trash.html:32
-msgid " <p>Purge deleted datasets forever and irreversibly.</p> "
-msgstr ""
-
-#: ckanext/switzerland/templates/group/admins.html:11
-msgid "Administrators"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/edit.html:11
-#: ckanext/switzerland/templates/group/edit.html:17
-#: ckanext/switzerland/templates/group/edit_base.html:11
-#: ckanext/switzerland/templates/group/edit_base.html:17
-#: ckanext/switzerland/templates/group/members.html:17
-msgid "Manage"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/followers.html:11
-msgid "Followers"
-msgstr ""
-
 #: ckanext/switzerland/templates/group/index.html:5
 msgid "Add Group"
 msgstr "Categorie hinzufügen"
-
-#: ckanext/switzerland/templates/group/member_new.html:10
-#: ckanext/switzerland/templates/organization/member_new.html:10
-msgid "Existing User"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/member_new.html:13
-#: ckanext/switzerland/templates/organization/member_new.html:13
-msgid "If you wish to add an existing user, search for their username below."
-msgstr ""
-
-#: ckanext/switzerland/templates/group/member_new.html:32
-#: ckanext/switzerland/templates/organization/member_new.html:32
-msgid "Role"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/member_new.html:35
-#: ckanext/switzerland/templates/organization/member_new.html:35
-msgid "Are you sure you want to delete this member?"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/member_new.html:35
-#: ckanext/switzerland/templates/organization/bulk_process.html:57
-#: ckanext/switzerland/templates/organization/member_new.html:35
-msgid "Delete"
-msgstr "Gelöscht"
-
-#: ckanext/switzerland/templates/group/member_new.html:37
-msgid "Save"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/member_new.html:41
-#: ckanext/switzerland/templates/organization/member_new.html:41
-msgid "Add Member"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/members.html:11
-msgid "Members"
-msgstr ""
 
 #: ckanext/switzerland/templates/group/read_base.html:22
 #: ckanext/switzerland/templates/organization/read_base.html:18
@@ -505,19 +325,6 @@ msgid "{num} Dataset"
 msgid_plural "{num} Datasets"
 msgstr[0] "{num} Datensatz"
 msgstr[1] "{num} Datensätze"
-
-#: ckanext/switzerland/templates/group/snippets/info.html:7
-#: ckanext/switzerland/templates/organization/bulk_process.html:82
-#: ckanext/switzerland/templates/package/read.html:30
-#: ckanext/switzerland/templates/snippets/organization.html:7
-#: ckanext/switzerland/templates/snippets/package_item.html:42
-msgid "Deleted"
-msgstr "Gelöscht"
-
-#: ckanext/switzerland/templates/group/snippets/info.html:15
-#: ckanext/switzerland/templates/snippets/organization.html:17
-msgid "read more"
-msgstr ""
 
 #: ckanext/switzerland/templates/home/snippets/promoted.html:8
 msgid "opendata.swiss CKAN backend"
@@ -538,43 +345,6 @@ msgstr ""
 msgid "File URL"
 msgstr ""
 
-#: ckanext/switzerland/templates/macros/form.html:34
-msgid "Clear Upload"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/bulk_process.html:3
-#: ckanext/switzerland/templates/organization/bulk_process.html:11
-msgid "Edit datasets"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/bulk_process.html:16
-msgid " found for \"{query}\""
-msgstr " gefunden bei der Suche {query}"
-
-#: ckanext/switzerland/templates/organization/bulk_process.html:18
-msgid "Sorry no datasets found for \"{query}\""
-msgstr "Keine Datensätze gefunden bei der Suche {query}"
-
-#: ckanext/switzerland/templates/organization/bulk_process.html:27
-#: ckanext/switzerland/templates/organization/index.html:10
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:17
-#: ckanext/switzerland/templates/snippets/search_box.html:36
-msgid "Name Ascending"
-msgstr "Name aufsteigend"
-
-#: ckanext/switzerland/templates/organization/bulk_process.html:28
-#: ckanext/switzerland/templates/organization/index.html:10
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:18
-#: ckanext/switzerland/templates/snippets/search_box.html:37
-msgid "Name Descending"
-msgstr "Name absteigend"
-
-#: ckanext/switzerland/templates/organization/bulk_process.html:29
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:19
-#: ckanext/switzerland/templates/snippets/search_box.html:38
-msgid "Last Modified"
-msgstr "Zuletzt geändert"
-
 #: ckanext/switzerland/templates/organization/bulk_process.html:47
 msgid "Publish"
 msgstr "Veröffentlichen"
@@ -583,56 +353,12 @@ msgstr "Veröffentlichen"
 msgid "Make draft"
 msgstr "Entwurf machen"
 
-#: ckanext/switzerland/templates/organization/bulk_process.html:75
-#: ckanext/switzerland/templates/package/resource_edit_base.html:11
-#: ckanext/switzerland/templates/snippets/resource_subtitle.html:1
-msgid "Edit"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/bulk_process.html:98
-msgid "This organization has no datasets associated to it"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/index.html:5
-msgid "Add Organization"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/index.html:10
-msgid "Search organizations..."
-msgstr "Organisationen suchen..."
-
-#: ckanext/switzerland/templates/organization/member_new.html:22
-msgid "Username"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/member_new.html:37
-msgid "Update Member"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/new.html:7
-msgid "Create an Organization"
-msgstr "Organisation anlegen"
-
-#: ckanext/switzerland/templates/organization/read.html:20
-msgid "Submit"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/read_base.html:20
-#: ckanext/switzerland/templates/package/read_base.html:7
-#: ckanext/switzerland/templates/user/read_base.html:7
-msgid "Activity Stream"
-msgstr ""
-
 #: ckanext/switzerland/templates/organization/snippets/organization_search_form.html:15
 #: ckanext/switzerland/templates/snippets/search_form.html:27
 #: ckanext/switzerland/templates/snippets/search_form.html:29
 #: ckanext/switzerland/templates/snippets/search_form.html:31
 msgid "Reset search"
 msgstr "Suche zurücksetzen"
-
-#: ckan/templates/package/base_form_page.html:22
-msgid "What are datasets?"
-msgstr "Datensatz"
 
 #: ckan/templates/package/base_form_page.html:25
 msgid ""
@@ -653,10 +379,6 @@ msgid ""
 " You're currently viewing an old version of this dataset. To see the "
 "current version, click <a href=\"%(url)s\">here</a>. "
 msgstr ""
-
-#: ckanext/switzerland/templates/package/read_base.html:4
-msgid "Dataset"
-msgstr "Datensatz"
 
 #: ckanext/switzerland/templates/package/snippets/additional_info.html:4
 msgid "Additional information"
@@ -688,10 +410,6 @@ msgstr ""
 #: ckanext/switzerland/templates/scheming/form_snippets/organization.html:24
 msgid "Dataset Publication"
 msgstr "Dataset veröffentlichen"
-
-#: ckanext/switzerland/templates/scheming/form_snippets/organization.html:25
-msgid "Visibility"
-msgstr "Sichtbarkeit"
 
 #: ckanext/switzerland/templates/scheming/form_snippets/organization.html:28
 msgid "Public"
@@ -737,24 +455,6 @@ msgstr ""
 "Hier können Sie eine oder mehrere Kategorien auswählen, auf die sich der Datensatz bezieht. "
 "Die Definition einer Kategorie erhöht die Auffindbarkeit der Daten."
 
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:16
-#: ckanext/switzerland/templates/snippets/search_box.html:35
-msgid "Relevance"
-msgstr "Relevanz"
-
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:20
-#: ckanext/switzerland/templates/snippets/search_box.html:39
-msgid "Popular"
-msgstr "Populär"
-
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:28
-msgid "Datasets available to add to this showcase"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:43
-msgid "Add to Showcase"
-msgstr ""
-
 #: ckanext/switzerland/templates/showcase/manage_datasets.html:80
 msgid "No datasets could be found"
 msgstr "Keinen Datensatz gefunden"
@@ -767,45 +467,9 @@ msgstr "Datensätze in diesem Showcase"
 msgid "Remove from Showcase"
 msgstr "Datensatz aus diesen Showcase entfernen"
 
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:132
-msgid "This showcase has no datasets associated to it"
-msgstr "Dieser Showcase hat keine Beschreibung"
-
-#: ckanext/switzerland/templates/showcase/new_package_form.html:7
-msgid "Title"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/new_package_form.html:7
-msgid "eg. A descriptive title"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/new_package_form.html:16
-msgid "eg. my-showcase"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/new_package_form.html:20
-msgid "Description"
-msgstr "Beschreibung"
-
-#: ckanext/switzerland/templates/showcase/new_package_form.html:20
-msgid "eg. Some useful notes about the data"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/new_package_form.html:25
-msgid "eg. economy, mental health, government"
-msgstr ""
-
 #: ckanext/switzerland/templates/showcase/search.html:6
 msgid "Add Showcase"
 msgstr "Showcase hinzufügen"
-
-#: ckanext/switzerland/templates/showcase/snippets/showcase_info.html:21
-msgid "Submitted by"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/snippets/showcase_info.html:27
-msgid "Launch website"
-msgstr ""
 
 #: ckanext/switzerland/templates/showcase/snippets/showcase_info.html:37
 msgid "Datasets in Showcase"
@@ -815,14 +479,6 @@ msgstr "Datensätze in Showcase"
 msgid "These datasets are not (yet) available on opendata.swiss."
 msgstr "Diese Datensätze sind (noch) nicht auf opendata.swiss verfügbar."
 
-#: ckanext/switzerland/templates/snippets/activity_item.html:3
-msgid "New activity item"
-msgstr ""
-
-#: ckanext/switzerland/templates/snippets/add_dataset.html:6
-msgid "Add Dataset"
-msgstr "Datensatz hinzufügen"
-
 #: ckanext/switzerland/templates/snippets/add_source_button.html:4
 msgid "Add Harvest Source"
 msgstr "Katalog Endpunkt hinzufügen"
@@ -831,17 +487,9 @@ msgstr "Katalog Endpunkt hinzufügen"
 msgid "Show More {facet_type}"
 msgstr "Zeige mehr {facet_type}"
 
-#: ckanext/switzerland/templates/snippets/facet_list.html:93
-msgid "Show Only Popular {facet_type}"
-msgstr ""
-
 #: ckanext/switzerland/templates/snippets/facet_list.html:97
 msgid "There are no {facet_type} that match this search"
 msgstr "Zu dieser Suche gibt es keine {facet_type}"
-
-#: ckanext/switzerland/templates/snippets/organization.html:20
-msgid "There is no description for this organization"
-msgstr ""
 
 #: ckanext/switzerland/templates/snippets/package_item.html:61
 msgid "This dataset has no description"
@@ -902,37 +550,6 @@ msgstr[1] "{number} Organisationen gefunden"
 #: ckanext/switzerland/templates/snippets/search_result_text.html:30
 msgid "No organizations found"
 msgstr "Keine Organisation gefunden"
-
-#: ckanext/switzerland/templates/user/dashboard.html:8
-msgid "Edit settings"
-msgstr ""
-
-#: ckanext/switzerland/templates/user/dashboard.html:11
-#: ckanext/switzerland/templates/user/dashboard.html:27
-msgid "My Datasets"
-msgstr ""
-
-#: ckanext/switzerland/templates/user/dashboard.html:12
-#: ckanext/switzerland/templates/user/dashboard_organizations.html:8
-msgid "My Organizations"
-msgstr ""
-
-#: ckanext/switzerland/templates/user/dashboard.html:33
-msgid "You haven't created any datasets."
-msgstr ""
-
-#: ckanext/switzerland/templates/user/dashboard.html:35
-#: ckanext/switzerland/templates/user/dashboard_organizations.html:28
-msgid "Create one now?"
-msgstr ""
-
-#: ckanext/switzerland/templates/user/dashboard_organizations.html:26
-msgid "You are not a member of any organizations."
-msgstr ""
-
-#: ckanext/switzerland/templates/user/list.html:9
-msgid "Add User"
-msgstr "Benutzer hinzufügen"
 
 #: value for `draft` dataset facet
 msgid "True"

--- a/ckanext/switzerland/i18n/de/LC_MESSAGES/ckanext-switzerland.po
+++ b/ckanext/switzerland/i18n/de/LC_MESSAGES/ckanext-switzerland.po
@@ -49,6 +49,11 @@ msgstr "Entwurf"
 msgid "Categories"
 msgstr "Kategorien"
 
+#: ckan/logic/converters.py:173 ckan/logic/validators.py:246
+#: ckanext/stats/templates/ckanext/stats/index.html:113
+msgid "Group"
+msgstr "Kategorie"
+
 #: ckanext/switzerland/plugins.py:80 ckanext/switzerland/plugins.py:93
 #: ckanext/switzerland/plugins.py:108
 msgid "Keywords"
@@ -291,16 +296,6 @@ msgstr ""
 #, python-format
 msgid "unexpected choice \"%s\""
 msgstr ""
-
-#: ckanext/switzerland/templates/group/read_base.html:21
-#: ckanext/switzerland/templates/header.html:19
-#: ckanext/switzerland/templates/organization/bulk_process.html:20
-#: ckanext/switzerland/templates/organization/read_base.html:17
-#: ckanext/switzerland/templates/package/base.html:9
-#: ckanext/switzerland/templates/package/base.html:13
-#: ckanext/switzerland/templates/user/read_base.html:4
-msgid "Datasets"
-msgstr "Datensätze"
 
 #: ckanext/switzerland/templates/header.html:25
 #: ckanext/switzerland/templates/package/read_base.html:5

--- a/ckanext/switzerland/i18n/fr/LC_MESSAGES/ckanext-switzerland.po
+++ b/ckanext/switzerland/i18n/fr/LC_MESSAGES/ckanext-switzerland.po
@@ -105,21 +105,6 @@ msgstr "Type de contenu"
 msgid "Groups"
 msgstr "Catégories"
 
-#: ckanext/switzerland/controllers/group.py:111
-#: ckanext/switzerland/controllers/organization.py:119
-#: ckanext/switzerland/templates/showcase/new_package_form.html:25
-msgid "Tags"
-msgstr ""
-
-#: ckanext/switzerland/controllers/group.py:113
-#: ckanext/switzerland/controllers/organization.py:121
-msgid "Licenses"
-msgstr ""
-
-#: ckanext/switzerland/controllers/organization.py:227
-msgid "Not authorized to see this page"
-msgstr ""
-
 #: ckanext/switzerland/controllers/organization.py:288
 msgid "Only POST is available"
 msgstr ""
@@ -127,34 +112,6 @@ msgstr ""
 #: ckanext/switzerland/controllers/perma.py:28
 msgid "Dataset not found"
 msgstr "Jeu de données introuvable"
-
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:60
-msgid "file"
-msgstr ""
-
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:68
-msgid "Please select the file to upload again"
-msgstr ""
-
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:72
-msgid "Remove"
-msgstr ""
-
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:87
-msgid "Upload a file on your computer"
-msgstr ""
-
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:109
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:178
-#: ckanext/switzerland/templates/showcase/new_package_form.html:16
-msgid "URL"
-msgstr ""
-
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:118
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:209
-#: ckanext/switzerland/templates/macros/form.html:16
-msgid "File"
-msgstr ""
 
 #: ckanext/switzerland/helpers/backend_helpers.py:179
 #: ckanext/switzerland/helpers/frontend_helpers.py:110
@@ -175,64 +132,6 @@ msgstr "Commune"
 #: ckanext/switzerland/helpers/frontend_helpers.py:113
 msgid "Other"
 msgstr "Autre"
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:33
-msgid "* Non-commercial Allowed / Commercial Allowed / Reference Not Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:35
-msgid ""
-"* Non-commercial Allowed / Commercial With Permission Allowed / Reference"
-" Not Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:37
-msgid ""
-"* Non-commercial Allowed / Commercial With Permission Allowed / Reference"
-" Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:39
-msgid "* Non-commercial Allowed / Commercial Allowed / Reference Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:41
-msgid "Non-commercial Allowed / Commercial Not Allowed / Reference Not Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:43
-msgid "Non-commercial Allowed / Commercial Not Allowed / Reference Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:45
-msgid ""
-"Non-commercial Not Allowed / Commercial Not Allowed / Reference Not "
-"Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:47
-msgid "Non-commercial Not Allowed / Commercial Not Allowed / Reference Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:49
-msgid "Non-commercial Not Allowed / Commercial Allowed / Reference Not Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:51
-msgid "Non-commercial Not Allowed / Commercial Allowed / Reference Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:53
-msgid ""
-"Non-commercial Not Allowed / Commercial With Permission Allowed / "
-"Reference Not Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:55
-msgid ""
-"Non-commercial Not Allowed / Commercial With Permission Allowed / "
-"Reference Required"
-msgstr ""
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:82
 msgid "Irregular"
@@ -392,102 +291,10 @@ msgstr ""
 msgid "unexpected choice \"%s\""
 msgstr ""
 
-#: ckanext/switzerland/templates/header.html:9
-#: ckanext/switzerland/templates/user/list.html:12
-msgid "Users"
-msgstr ""
-
-#: ckanext/switzerland/templates/header.html:15
-#: ckanext/switzerland/templates/source/base.html:6
-#: ckanext/switzerland/templates/source/base.html:9
-msgid "Harvest Sources"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/read_base.html:21
-#: ckanext/switzerland/templates/header.html:19
-#: ckanext/switzerland/templates/organization/bulk_process.html:20
-#: ckanext/switzerland/templates/organization/read_base.html:17
-#: ckanext/switzerland/templates/package/base.html:9
-#: ckanext/switzerland/templates/package/base.html:13
-#: ckanext/switzerland/templates/user/read_base.html:4
-msgid "Datasets"
-msgstr ""
-
 #: ckanext/switzerland/templates/header.html:25
 #: ckanext/switzerland/templates/package/read_base.html:5
 msgid "Showcases"
 msgstr "Showcases"
-
-#: ckanext/switzerland/templates/admin/trash.html:20
-msgid "Purge"
-msgstr ""
-
-#: ckanext/switzerland/templates/admin/trash.html:29
-msgid "Trash"
-msgstr ""
-
-#: ckanext/switzerland/templates/admin/trash.html:32
-msgid " <p>Purge deleted datasets forever and irreversibly.</p> "
-msgstr ""
-
-#: ckanext/switzerland/templates/group/admins.html:11
-msgid "Administrators"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/edit.html:11
-#: ckanext/switzerland/templates/group/edit.html:17
-#: ckanext/switzerland/templates/group/edit_base.html:11
-#: ckanext/switzerland/templates/group/edit_base.html:17
-#: ckanext/switzerland/templates/group/members.html:17
-msgid "Manage"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/followers.html:11
-msgid "Followers"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/index.html:5
-msgid "Add Group"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/member_new.html:10
-#: ckanext/switzerland/templates/organization/member_new.html:10
-msgid "Existing User"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/member_new.html:13
-#: ckanext/switzerland/templates/organization/member_new.html:13
-msgid "If you wish to add an existing user, search for their username below."
-msgstr ""
-
-#: ckanext/switzerland/templates/group/member_new.html:32
-#: ckanext/switzerland/templates/organization/member_new.html:32
-msgid "Role"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/member_new.html:35
-#: ckanext/switzerland/templates/organization/member_new.html:35
-msgid "Are you sure you want to delete this member?"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/member_new.html:35
-#: ckanext/switzerland/templates/organization/bulk_process.html:57
-#: ckanext/switzerland/templates/organization/member_new.html:35
-msgid "Delete"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/member_new.html:37
-msgid "Save"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/member_new.html:41
-#: ckanext/switzerland/templates/organization/member_new.html:41
-msgid "Add Member"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/members.html:11
-msgid "Members"
-msgstr ""
 
 #: ckanext/switzerland/templates/group/read_base.html:22
 #: ckanext/switzerland/templates/organization/read_base.html:18
@@ -503,19 +310,6 @@ msgid "{num} Dataset"
 msgid_plural "{num} Datasets"
 msgstr[0] "{num} jeu de données"
 msgstr[1] "{num} jeux de données"
-
-#: ckanext/switzerland/templates/group/snippets/info.html:7
-#: ckanext/switzerland/templates/organization/bulk_process.html:82
-#: ckanext/switzerland/templates/package/read.html:30
-#: ckanext/switzerland/templates/snippets/organization.html:7
-#: ckanext/switzerland/templates/snippets/package_item.html:42
-msgid "Deleted"
-msgstr "Supprimé"
-
-#: ckanext/switzerland/templates/group/snippets/info.html:15
-#: ckanext/switzerland/templates/snippets/organization.html:17
-msgid "read more"
-msgstr ""
 
 #: ckanext/switzerland/templates/home/snippets/promoted.html:8
 msgid "opendata.swiss CKAN backend"
@@ -536,43 +330,6 @@ msgstr ""
 msgid "File URL"
 msgstr ""
 
-#: ckanext/switzerland/templates/macros/form.html:34
-msgid "Clear Upload"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/bulk_process.html:3
-#: ckanext/switzerland/templates/organization/bulk_process.html:11
-msgid "Edit datasets"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/bulk_process.html:16
-msgid " found for \"{query}\""
-msgstr " trouvée pour '{query}'"
-
-#: ckanext/switzerland/templates/organization/bulk_process.html:18
-msgid "Sorry no datasets found for \"{query}\""
-msgstr "Aucun showcase trouvée pour '{query}'"
-
-#: ckanext/switzerland/templates/organization/bulk_process.html:27
-#: ckanext/switzerland/templates/organization/index.html:10
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:17
-#: ckanext/switzerland/templates/snippets/search_box.html:36
-msgid "Name Ascending"
-msgstr "Nom croissant"
-
-#: ckanext/switzerland/templates/organization/bulk_process.html:28
-#: ckanext/switzerland/templates/organization/index.html:10
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:18
-#: ckanext/switzerland/templates/snippets/search_box.html:37
-msgid "Name Descending"
-msgstr "Nom décroissant"
-
-#: ckanext/switzerland/templates/organization/bulk_process.html:29
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:19
-#: ckanext/switzerland/templates/snippets/search_box.html:38
-msgid "Last Modified"
-msgstr "Dernière modification"
-
 #: ckanext/switzerland/templates/organization/bulk_process.html:47
 msgid "Publish"
 msgstr "Publier"
@@ -581,56 +338,12 @@ msgstr "Publier"
 msgid "Make draft"
 msgstr "Faire brouillon"
 
-#: ckanext/switzerland/templates/organization/bulk_process.html:75
-#: ckanext/switzerland/templates/package/resource_edit_base.html:11
-#: ckanext/switzerland/templates/snippets/resource_subtitle.html:1
-msgid "Edit"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/bulk_process.html:98
-msgid "This organization has no datasets associated to it"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/index.html:5
-msgid "Add Organization"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/index.html:10
-msgid "Search organizations..."
-msgstr "Rechercher des organisations..."
-
-#: ckanext/switzerland/templates/organization/member_new.html:22
-msgid "Username"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/member_new.html:37
-msgid "Update Member"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/new.html:7
-msgid "Create an Organization"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/read.html:20
-msgid "Submit"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/read_base.html:20
-#: ckanext/switzerland/templates/package/read_base.html:7
-#: ckanext/switzerland/templates/user/read_base.html:7
-msgid "Activity Stream"
-msgstr ""
-
 #: ckanext/switzerland/templates/organization/snippets/organization_search_form.html:15
 #: ckanext/switzerland/templates/snippets/search_form.html:27
 #: ckanext/switzerland/templates/snippets/search_form.html:29
 #: ckanext/switzerland/templates/snippets/search_form.html:31
 msgid "Reset search"
 msgstr "Réinitialiser la recherche"
-
-#: ckan/templates/package/base_form_page.html:22
-msgid "What are datasets?"
-msgstr "Jeu de données"
 
 #: ckan/templates/package/base_form_page.html:25
 msgid ""
@@ -645,20 +358,12 @@ msgstr ""
 "métadonnées de la classe dcat:Dataset (métadonnées d’un jeu de données) et "
 "décrit un seul jeu de données portant sur un certain thème. "
 
-#: ckanext/switzerland/templates/package/base.html:14
-msgid "Create Dataset"
-msgstr ""
-
 #: ckanext/switzerland/templates/package/read.html:16
 #, python-format
 msgid ""
 " You're currently viewing an old version of this dataset. To see the "
 "current version, click <a href=\"%(url)s\">here</a>. "
 msgstr ""
-
-#: ckanext/switzerland/templates/package/read_base.html:4
-msgid "Dataset"
-msgstr "Jeu de données"
 
 #: ckanext/switzerland/templates/package/snippets/additional_info.html:4
 msgid "Additional information"
@@ -689,10 +394,6 @@ msgstr ""
 
 #: ckanext/switzerland/templates/scheming/form_snippets/organization.html:24
 msgid "Dataset Publication"
-msgstr ""
-
-#: ckanext/switzerland/templates/scheming/form_snippets/organization.html:25
-msgid "Visibility"
 msgstr ""
 
 #: ckanext/switzerland/templates/scheming/form_snippets/organization.html:28
@@ -727,10 +428,6 @@ msgstr "API (JSON)"
 msgid "Download XML"
 msgstr "Télécharger XML"
 
-#: ckanext/switzerland/templates/scheming/package/snippets/package_form.html:25
-msgid "This field is required"
-msgstr ""
-
 #: ckanext/switzerland/templates/scheming/package/snippets/package_form.html:61
 msgid ""
 "Here you can choose one or more categories to which the data set relates. "
@@ -738,24 +435,6 @@ msgid ""
 msgstr ""
 "Ici, vous pouvez choisir une ou plusieurs catégories auxquelles l'ensemble de données se rapporte. "
 "La définition d'une catégorie augmente la facilité de recherche des données."
-
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:16
-#: ckanext/switzerland/templates/snippets/search_box.html:35
-msgid "Relevance"
-msgstr "Pertinence"
-
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:20
-#: ckanext/switzerland/templates/snippets/search_box.html:39
-msgid "Popular"
-msgstr "Populaire"
-
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:28
-msgid "Datasets available to add to this showcase"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:43
-msgid "Add to Showcase"
-msgstr ""
 
 #: ckanext/switzerland/templates/showcase/manage_datasets.html:80
 msgid "No datasets could be found"
@@ -769,46 +448,6 @@ msgstr "Jeux de données dans le showcase"
 msgid "Remove from Showcase"
 msgstr "Supprimer le jeu de données de ce showcase"
 
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:132
-msgid "This showcase has no datasets associated to it"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/new_package_form.html:7
-msgid "Title"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/new_package_form.html:7
-msgid "eg. A descriptive title"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/new_package_form.html:16
-msgid "eg. my-showcase"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/new_package_form.html:20
-msgid "Description"
-msgstr "Description"
-
-#: ckanext/switzerland/templates/showcase/new_package_form.html:20
-msgid "eg. Some useful notes about the data"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/new_package_form.html:25
-msgid "eg. economy, mental health, government"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/search.html:6
-msgid "Add Showcase"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/snippets/showcase_info.html:21
-msgid "Submitted by"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/snippets/showcase_info.html:27
-msgid "Launch website"
-msgstr ""
-
 #: ckanext/switzerland/templates/showcase/snippets/showcase_info.html:37
 msgid "Datasets in Showcase"
 msgstr "Jeux de données dans le showcase"
@@ -817,29 +456,13 @@ msgstr "Jeux de données dans le showcase"
 msgid "These datasets are not (yet) available on opendata.swiss."
 msgstr "Ces jeux de données ne sont pas (encore) disponibles sur opendata.swiss."
 
-#: ckanext/switzerland/templates/snippets/activity_item.html:3
-msgid "New activity item"
-msgstr ""
-
-#: ckanext/switzerland/templates/snippets/add_source_button.html:4
-msgid "Add Harvest Source"
-msgstr ""
-
 #: ckanext/switzerland/templates/snippets/facet_list.html:90
 msgid "Show More {facet_type}"
 msgstr "Montrer plus de {facet_type}"
 
-#: ckanext/switzerland/templates/snippets/facet_list.html:93
-msgid "Show Only Popular {facet_type}"
-msgstr ""
-
 #: ckanext/switzerland/templates/snippets/facet_list.html:97
 msgid "There are no {facet_type} that match this search"
 msgstr "Il n'y a pas de {facet_type} correspondant à cette recherche."
-
-#: ckanext/switzerland/templates/snippets/organization.html:20
-msgid "There is no description for this organization"
-msgstr ""
 
 #: ckanext/switzerland/templates/snippets/package_item.html:61
 msgid "This dataset has no description"
@@ -900,37 +523,6 @@ msgstr[1] "{number} organisations trouvées"
 #: ckanext/switzerland/templates/snippets/search_result_text.html:30
 msgid "No organizations found"
 msgstr "Aucune organisation trouvée"
-
-#: ckanext/switzerland/templates/user/dashboard.html:8
-msgid "Edit settings"
-msgstr ""
-
-#: ckanext/switzerland/templates/user/dashboard.html:11
-#: ckanext/switzerland/templates/user/dashboard.html:27
-msgid "My Datasets"
-msgstr ""
-
-#: ckanext/switzerland/templates/user/dashboard.html:12
-#: ckanext/switzerland/templates/user/dashboard_organizations.html:8
-msgid "My Organizations"
-msgstr ""
-
-#: ckanext/switzerland/templates/user/dashboard.html:33
-msgid "You haven't created any datasets."
-msgstr ""
-
-#: ckanext/switzerland/templates/user/dashboard.html:35
-#: ckanext/switzerland/templates/user/dashboard_organizations.html:28
-msgid "Create one now?"
-msgstr ""
-
-#: ckanext/switzerland/templates/user/dashboard_organizations.html:26
-msgid "You are not a member of any organizations."
-msgstr ""
-
-#: ckanext/switzerland/templates/user/list.html:9
-msgid "Add User"
-msgstr ""
 
 #: value for `draft` dataset facet
 msgid "True"

--- a/ckanext/switzerland/i18n/fr/LC_MESSAGES/ckanext-switzerland.po
+++ b/ckanext/switzerland/i18n/fr/LC_MESSAGES/ckanext-switzerland.po
@@ -105,6 +105,11 @@ msgstr "Type de contenu"
 msgid "Groups"
 msgstr "Catégories"
 
+#: ckan/logic/converters.py:173 ckan/logic/validators.py:246
+#: ckanext/stats/templates/ckanext/stats/index.html:113
+msgid "Group"
+msgstr "Catégorie"
+
 #: ckanext/switzerland/controllers/organization.py:288
 msgid "Only POST is available"
 msgstr ""
@@ -296,6 +301,10 @@ msgstr ""
 msgid "Showcases"
 msgstr "Showcases"
 
+#: ckanext/switzerland/templates/group/index.html:5
+msgid "Add Group"
+msgstr "Ajouter une catégorie"
+
 #: ckanext/switzerland/templates/group/read_base.html:22
 #: ckanext/switzerland/templates/organization/read_base.html:18
 msgid "About"
@@ -394,7 +403,7 @@ msgstr ""
 
 #: ckanext/switzerland/templates/scheming/form_snippets/organization.html:24
 msgid "Dataset Publication"
-msgstr ""
+msgstr "Publier le jeu de données"
 
 #: ckanext/switzerland/templates/scheming/form_snippets/organization.html:28
 msgid "Public"
@@ -402,7 +411,7 @@ msgstr "Publié"
 
 #: ckanext/switzerland/templates/scheming/form_snippets/organization.html:34
 msgid "To publish the dataset: set its visibility to published"
-msgstr ""
+msgstr "Pour publier le jeu de données : définissez sa visibilité sur publié"
 
 #: ckanext/switzerland/templates/scheming/form_snippets/organization_slug.html:13
 msgid "Name (Slug)"
@@ -447,6 +456,10 @@ msgstr "Jeux de données dans le showcase"
 #: ckanext/switzerland/templates/showcase/manage_datasets.html:101
 msgid "Remove from Showcase"
 msgstr "Supprimer le jeu de données de ce showcase"
+
+#: ckanext/switzerland/templates/showcase/search.html:6
+msgid "Add Showcase"
+msgstr "Ajouter un showcase"
 
 #: ckanext/switzerland/templates/showcase/snippets/showcase_info.html:37
 msgid "Datasets in Showcase"
@@ -535,4 +548,3 @@ msgstr "Faux"
 #: ckanext/switzerland/templates/package/snippets/package_form.html:3
 msgid "Next: Add Distributions"
 msgstr "Suivant : Ajouter des distributions"
-

--- a/ckanext/switzerland/i18n/it/LC_MESSAGES/ckanext-switzerland.po
+++ b/ckanext/switzerland/i18n/it/LC_MESSAGES/ckanext-switzerland.po
@@ -104,21 +104,6 @@ msgstr "Tipo di contenuto"
 msgid "Groups"
 msgstr "Categorie"
 
-#: ckanext/switzerland/controllers/group.py:111
-#: ckanext/switzerland/controllers/organization.py:119
-#: ckanext/switzerland/templates/showcase/new_package_form.html:25
-msgid "Tags"
-msgstr ""
-
-#: ckanext/switzerland/controllers/group.py:113
-#: ckanext/switzerland/controllers/organization.py:121
-msgid "Licenses"
-msgstr ""
-
-#: ckanext/switzerland/controllers/organization.py:227
-msgid "Not authorized to see this page"
-msgstr ""
-
 #: ckanext/switzerland/controllers/organization.py:288
 msgid "Only POST is available"
 msgstr ""
@@ -126,34 +111,6 @@ msgstr ""
 #: ckanext/switzerland/controllers/perma.py:28
 msgid "Dataset not found"
 msgstr "Dataset non trovato"
-
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:60
-msgid "file"
-msgstr ""
-
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:68
-msgid "Please select the file to upload again"
-msgstr ""
-
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:72
-msgid "Remove"
-msgstr ""
-
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:87
-msgid "Upload a file on your computer"
-msgstr ""
-
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:109
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:178
-#: ckanext/switzerland/templates/showcase/new_package_form.html:16
-msgid "URL"
-msgstr ""
-
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:118
-#: ckanext/switzerland/fanstatic/ogdch_file_upload.js:209
-#: ckanext/switzerland/templates/macros/form.html:16
-msgid "File"
-msgstr ""
 
 #: ckanext/switzerland/helpers/backend_helpers.py:179
 #: ckanext/switzerland/helpers/frontend_helpers.py:110
@@ -174,64 +131,6 @@ msgstr "Comune"
 #: ckanext/switzerland/helpers/frontend_helpers.py:113
 msgid "Other"
 msgstr "Altro"
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:33
-msgid "* Non-commercial Allowed / Commercial Allowed / Reference Not Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:35
-msgid ""
-"* Non-commercial Allowed / Commercial With Permission Allowed / Reference"
-" Not Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:37
-msgid ""
-"* Non-commercial Allowed / Commercial With Permission Allowed / Reference"
-" Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:39
-msgid "* Non-commercial Allowed / Commercial Allowed / Reference Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:41
-msgid "Non-commercial Allowed / Commercial Not Allowed / Reference Not Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:43
-msgid "Non-commercial Allowed / Commercial Not Allowed / Reference Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:45
-msgid ""
-"Non-commercial Not Allowed / Commercial Not Allowed / Reference Not "
-"Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:47
-msgid "Non-commercial Not Allowed / Commercial Not Allowed / Reference Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:49
-msgid "Non-commercial Not Allowed / Commercial Allowed / Reference Not Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:51
-msgid "Non-commercial Not Allowed / Commercial Allowed / Reference Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:53
-msgid ""
-"Non-commercial Not Allowed / Commercial With Permission Allowed / "
-"Reference Not Required"
-msgstr ""
-
-#: ckanext/switzerland/helpers/dataset_form_helpers.py:55
-msgid ""
-"Non-commercial Not Allowed / Commercial With Permission Allowed / "
-"Reference Required"
-msgstr ""
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:82
 msgid "Irregular"
@@ -391,102 +290,10 @@ msgstr ""
 msgid "unexpected choice \"%s\""
 msgstr ""
 
-#: ckanext/switzerland/templates/header.html:9
-#: ckanext/switzerland/templates/user/list.html:12
-msgid "Users"
-msgstr ""
-
-#: ckanext/switzerland/templates/header.html:15
-#: ckanext/switzerland/templates/source/base.html:6
-#: ckanext/switzerland/templates/source/base.html:9
-msgid "Harvest Sources"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/read_base.html:21
-#: ckanext/switzerland/templates/header.html:19
-#: ckanext/switzerland/templates/organization/bulk_process.html:20
-#: ckanext/switzerland/templates/organization/read_base.html:17
-#: ckanext/switzerland/templates/package/base.html:9
-#: ckanext/switzerland/templates/package/base.html:13
-#: ckanext/switzerland/templates/user/read_base.html:4
-msgid "Datasets"
-msgstr "Dataset"
-
 #: ckanext/switzerland/templates/header.html:25
 #: ckanext/switzerland/templates/package/read_base.html:5
 msgid "Showcases"
 msgstr "Showcases"
-
-#: ckanext/switzerland/templates/admin/trash.html:20
-msgid "Purge"
-msgstr ""
-
-#: ckanext/switzerland/templates/admin/trash.html:29
-msgid "Trash"
-msgstr ""
-
-#: ckanext/switzerland/templates/admin/trash.html:32
-msgid " <p>Purge deleted datasets forever and irreversibly.</p> "
-msgstr ""
-
-#: ckanext/switzerland/templates/group/admins.html:11
-msgid "Administrators"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/edit.html:11
-#: ckanext/switzerland/templates/group/edit.html:17
-#: ckanext/switzerland/templates/group/edit_base.html:11
-#: ckanext/switzerland/templates/group/edit_base.html:17
-#: ckanext/switzerland/templates/group/members.html:17
-msgid "Manage"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/followers.html:11
-msgid "Followers"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/index.html:5
-msgid "Add Group"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/member_new.html:10
-#: ckanext/switzerland/templates/organization/member_new.html:10
-msgid "Existing User"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/member_new.html:13
-#: ckanext/switzerland/templates/organization/member_new.html:13
-msgid "If you wish to add an existing user, search for their username below."
-msgstr ""
-
-#: ckanext/switzerland/templates/group/member_new.html:32
-#: ckanext/switzerland/templates/organization/member_new.html:32
-msgid "Role"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/member_new.html:35
-#: ckanext/switzerland/templates/organization/member_new.html:35
-msgid "Are you sure you want to delete this member?"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/member_new.html:35
-#: ckanext/switzerland/templates/organization/bulk_process.html:57
-#: ckanext/switzerland/templates/organization/member_new.html:35
-msgid "Delete"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/member_new.html:37
-msgid "Save"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/member_new.html:41
-#: ckanext/switzerland/templates/organization/member_new.html:41
-msgid "Add Member"
-msgstr ""
-
-#: ckanext/switzerland/templates/group/members.html:11
-msgid "Members"
-msgstr ""
 
 #: ckanext/switzerland/templates/group/read_base.html:22
 #: ckanext/switzerland/templates/organization/read_base.html:18
@@ -502,19 +309,6 @@ msgid "{num} Dataset"
 msgid_plural "{num} Datasets"
 msgstr[0] "{num} dataset"
 msgstr[1] "{num} dataset"
-
-#: ckanext/switzerland/templates/group/snippets/info.html:7
-#: ckanext/switzerland/templates/organization/bulk_process.html:82
-#: ckanext/switzerland/templates/package/read.html:30
-#: ckanext/switzerland/templates/snippets/organization.html:7
-#: ckanext/switzerland/templates/snippets/package_item.html:42
-msgid "Deleted"
-msgstr "Cancellato"
-
-#: ckanext/switzerland/templates/group/snippets/info.html:15
-#: ckanext/switzerland/templates/snippets/organization.html:17
-msgid "read more"
-msgstr ""
 
 #: ckanext/switzerland/templates/home/snippets/promoted.html:8
 msgid "opendata.swiss CKAN backend"
@@ -535,43 +329,6 @@ msgstr ""
 msgid "File URL"
 msgstr ""
 
-#: ckanext/switzerland/templates/macros/form.html:34
-msgid "Clear Upload"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/bulk_process.html:3
-#: ckanext/switzerland/templates/organization/bulk_process.html:11
-msgid "Edit datasets"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/bulk_process.html:16
-msgid " found for \"{query}\""
-msgstr " trovato per '{query}'"
-
-#: ckanext/switzerland/templates/organization/bulk_process.html:18
-msgid "Sorry no datasets found for \"{query}\""
-msgstr "Nessuno showcase trovato per '{query}'"
-
-#: ckanext/switzerland/templates/organization/bulk_process.html:27
-#: ckanext/switzerland/templates/organization/index.html:10
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:17
-#: ckanext/switzerland/templates/snippets/search_box.html:36
-msgid "Name Ascending"
-msgstr "Nome crescente"
-
-#: ckanext/switzerland/templates/organization/bulk_process.html:28
-#: ckanext/switzerland/templates/organization/index.html:10
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:18
-#: ckanext/switzerland/templates/snippets/search_box.html:37
-msgid "Name Descending"
-msgstr "Nome decrescente"
-
-#: ckanext/switzerland/templates/organization/bulk_process.html:29
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:19
-#: ckanext/switzerland/templates/snippets/search_box.html:38
-msgid "Last Modified"
-msgstr "Ultima modifica"
-
 #: ckanext/switzerland/templates/organization/bulk_process.html:47
 msgid "Publish"
 msgstr "Pubblica"
@@ -580,46 +337,6 @@ msgstr "Pubblica"
 msgid "Make draft"
 msgstr "Rendi bozza"
 
-#: ckanext/switzerland/templates/organization/bulk_process.html:75
-#: ckanext/switzerland/templates/package/resource_edit_base.html:11
-#: ckanext/switzerland/templates/snippets/resource_subtitle.html:1
-msgid "Edit"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/bulk_process.html:98
-msgid "This organization has no datasets associated to it"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/index.html:5
-msgid "Add Organization"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/index.html:10
-msgid "Search organizations..."
-msgstr "Cerca organizzazioni..."
-
-#: ckanext/switzerland/templates/organization/member_new.html:22
-msgid "Username"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/member_new.html:37
-msgid "Update Member"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/new.html:7
-msgid "Create an Organization"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/read.html:20
-msgid "Submit"
-msgstr ""
-
-#: ckanext/switzerland/templates/organization/read_base.html:20
-#: ckanext/switzerland/templates/package/read_base.html:7
-#: ckanext/switzerland/templates/user/read_base.html:7
-msgid "Activity Stream"
-msgstr ""
-
 #: ckanext/switzerland/templates/organization/snippets/organization_search_form.html:15
 #: ckanext/switzerland/templates/snippets/search_form.html:27
 #: ckanext/switzerland/templates/snippets/search_form.html:29
@@ -627,20 +344,12 @@ msgstr ""
 msgid "Reset search"
 msgstr "Resetta la ricerca"
 
-#: ckanext/switzerland/templates/package/base.html:14
-msgid "Create Dataset"
-msgstr ""
-
 #: ckanext/switzerland/templates/package/read.html:16
 #, python-format
 msgid ""
 " You're currently viewing an old version of this dataset. To see the "
 "current version, click <a href=\"%(url)s\">here</a>. "
 msgstr ""
-
-#: ckanext/switzerland/templates/package/read_base.html:4
-msgid "Dataset"
-msgstr "Dataset"
 
 #: ckanext/switzerland/templates/package/snippets/additional_info.html:4
 msgid "Additional information"
@@ -671,10 +380,6 @@ msgstr ""
 
 #: ckanext/switzerland/templates/scheming/form_snippets/organization.html:24
 msgid "Dataset Publication"
-msgstr ""
-
-#: ckanext/switzerland/templates/scheming/form_snippets/organization.html:25
-msgid "Visibility"
 msgstr ""
 
 #: ckanext/switzerland/templates/scheming/form_snippets/organization.html:28
@@ -709,10 +414,6 @@ msgstr "API (JSON)"
 msgid "Download XML"
 msgstr "Scarica XML"
 
-#: ckanext/switzerland/templates/scheming/package/snippets/package_form.html:25
-msgid "This field is required"
-msgstr ""
-
 #: ckanext/switzerland/templates/scheming/package/snippets/package_form.html:61
 msgid ""
 "Here you can choose one or more categories to which the data set relates. "
@@ -720,24 +421,6 @@ msgid ""
 msgstr ""
 "Qui puoi scegliere una o più categorie a cui il set di dati si riferisce. "
 "Definendo una categoria si aumenta la reperibilità dei dati."
-
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:16
-#: ckanext/switzerland/templates/snippets/search_box.html:35
-msgid "Relevance"
-msgstr "Rilevanza"
-
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:20
-#: ckanext/switzerland/templates/snippets/search_box.html:39
-msgid "Popular"
-msgstr "Popolare"
-
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:28
-msgid "Datasets available to add to this showcase"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:43
-msgid "Add to Showcase"
-msgstr ""
 
 #: ckanext/switzerland/templates/showcase/manage_datasets.html:80
 msgid "No datasets could be found"
@@ -751,46 +434,6 @@ msgstr "Dataset in Showcase"
 msgid "Remove from Showcase"
 msgstr "Elimina il dataset da questo showcase"
 
-#: ckanext/switzerland/templates/showcase/manage_datasets.html:132
-msgid "This showcase has no datasets associated to it"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/new_package_form.html:7
-msgid "Title"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/new_package_form.html:7
-msgid "eg. A descriptive title"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/new_package_form.html:16
-msgid "eg. my-showcase"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/new_package_form.html:20
-msgid "Description"
-msgstr "Descrizione"
-
-#: ckanext/switzerland/templates/showcase/new_package_form.html:20
-msgid "eg. Some useful notes about the data"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/new_package_form.html:25
-msgid "eg. economy, mental health, government"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/search.html:6
-msgid "Add Showcase"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/snippets/showcase_info.html:21
-msgid "Submitted by"
-msgstr ""
-
-#: ckanext/switzerland/templates/showcase/snippets/showcase_info.html:27
-msgid "Launch website"
-msgstr ""
-
 #: ckanext/switzerland/templates/showcase/snippets/showcase_info.html:37
 msgid "Datasets in Showcase"
 msgstr "Dataset in Showcase"
@@ -799,29 +442,13 @@ msgstr "Dataset in Showcase"
 msgid "These datasets are not (yet) available on opendata.swiss."
 msgstr "Questi Datasets non sono (ancora) disponibile su opendata.swiss."
 
-#: ckanext/switzerland/templates/snippets/activity_item.html:3
-msgid "New activity item"
-msgstr ""
-
-#: ckanext/switzerland/templates/snippets/add_source_button.html:4
-msgid "Add Harvest Source"
-msgstr ""
-
 #: ckanext/switzerland/templates/snippets/facet_list.html:90
 msgid "Show More {facet_type}"
 msgstr "Mostra più {facet_type}"
 
-#: ckanext/switzerland/templates/snippets/facet_list.html:93
-msgid "Show Only Popular {facet_type}"
-msgstr ""
-
 #: ckanext/switzerland/templates/snippets/facet_list.html:97
 msgid "There are no {facet_type} that match this search"
 msgstr "Per questa ricerca non ci sono {facet_type}"
-
-#: ckanext/switzerland/templates/snippets/organization.html:20
-msgid "There is no description for this organization"
-msgstr ""
 
 #: ckanext/switzerland/templates/snippets/package_item.html:61
 msgid "This dataset has no description"
@@ -882,37 +509,6 @@ msgstr[1] "{number} organizzazioni trovate"
 #: ckanext/switzerland/templates/snippets/search_result_text.html:30
 msgid "No organizations found"
 msgstr "Nessuna organizzazione trovata"
-
-#: ckanext/switzerland/templates/user/dashboard.html:8
-msgid "Edit settings"
-msgstr ""
-
-#: ckanext/switzerland/templates/user/dashboard.html:11
-#: ckanext/switzerland/templates/user/dashboard.html:27
-msgid "My Datasets"
-msgstr ""
-
-#: ckanext/switzerland/templates/user/dashboard.html:12
-#: ckanext/switzerland/templates/user/dashboard_organizations.html:8
-msgid "My Organizations"
-msgstr ""
-
-#: ckanext/switzerland/templates/user/dashboard.html:33
-msgid "You haven't created any datasets."
-msgstr ""
-
-#: ckanext/switzerland/templates/user/dashboard.html:35
-#: ckanext/switzerland/templates/user/dashboard_organizations.html:28
-msgid "Create one now?"
-msgstr ""
-
-#: ckanext/switzerland/templates/user/dashboard_organizations.html:26
-msgid "You are not a member of any organizations."
-msgstr ""
-
-#: ckanext/switzerland/templates/user/list.html:9
-msgid "Add User"
-msgstr ""
 
 #: value for `draft` dataset facet
 msgid "True"

--- a/ckanext/switzerland/i18n/it/LC_MESSAGES/ckanext-switzerland.po
+++ b/ckanext/switzerland/i18n/it/LC_MESSAGES/ckanext-switzerland.po
@@ -104,6 +104,11 @@ msgstr "Tipo di contenuto"
 msgid "Groups"
 msgstr "Categorie"
 
+#: ckan/logic/converters.py:173 ckan/logic/validators.py:246
+#: ckanext/stats/templates/ckanext/stats/index.html:113
+msgid "Group"
+msgstr "Categoria"
+
 #: ckanext/switzerland/controllers/organization.py:288
 msgid "Only POST is available"
 msgstr ""
@@ -295,6 +300,10 @@ msgstr ""
 msgid "Showcases"
 msgstr "Showcases"
 
+#: ckanext/switzerland/templates/group/index.html:5
+msgid "Add Group"
+msgstr "Aggiungi una categoria"
+
 #: ckanext/switzerland/templates/group/read_base.html:22
 #: ckanext/switzerland/templates/organization/read_base.html:18
 msgid "About"
@@ -380,7 +389,7 @@ msgstr ""
 
 #: ckanext/switzerland/templates/scheming/form_snippets/organization.html:24
 msgid "Dataset Publication"
-msgstr ""
+msgstr "Pubblica set di dati"
 
 #: ckanext/switzerland/templates/scheming/form_snippets/organization.html:28
 msgid "Public"
@@ -388,7 +397,7 @@ msgstr "Pubblicato"
 
 #: ckanext/switzerland/templates/scheming/form_snippets/organization.html:34
 msgid "To publish the dataset: set its visibility to published"
-msgstr ""
+msgstr "Per pubblicare il set di dati: imposta la sua visibilità su pubblicato"
 
 #: ckanext/switzerland/templates/scheming/form_snippets/organization_slug.html:13
 msgid "Name (Slug)"
@@ -433,6 +442,10 @@ msgstr "Dataset in Showcase"
 #: ckanext/switzerland/templates/showcase/manage_datasets.html:101
 msgid "Remove from Showcase"
 msgstr "Elimina il dataset da questo showcase"
+
+#: ckanext/switzerland/templates/showcase/search.html:6
+msgid "Add Showcase"
+msgstr "Aggiungi Showcase"
 
 #: ckanext/switzerland/templates/showcase/snippets/showcase_info.html:37
 msgid "Datasets in Showcase"


### PR DESCRIPTION
These translations were automatically added to the .po files with the update_catalog command in setup.py. Most of them are translations that already exist in ckan or in various ckanexts, and overwriting them with empty strings in our .po files removes the existing translations, so only English is shown. Some of them have translated strings that are the same as the ones in ckan, and it's not necessary to include those in our ckanext as well.