### PR TITLE
Fix two issues with datetimes

### DIFF
--- a/ckanext/switzerland/helpers/dataset_form_helpers.py
+++ b/ckanext/switzerland/helpers/dataset_form_helpers.py
@@ -13,12 +13,12 @@ from ckanext.switzerland.helpers.frontend_helpers import (
 from ckanext.switzerland.helpers.localize_utils import localize_by_language_order  # noqa
 from ckanext.switzerland.helpers.terms_of_use_utils import (
     TERMS_OF_USE_BY_ASK, TERMS_OF_USE_OPEN, TERMS_OF_USE_BY, TERMS_OF_USE_ASK)
+from dateutil.parser import parse
 
 
 ADDITIONAL_FORM_ROW_LIMIT = 10
 HIDE_ROW_CSS_CLASS = 'ogdch-hide-row'
 SHOW_ROW_CSS_CLASS = 'ogdch-show-row'
-ISODATE_FORMAT = '%Y-%m-%dT%H:%M:%S'
 
 log = logging.getLogger(__name__)
 
@@ -252,7 +252,7 @@ def ogdch_date_form_helper(date_value):
             return dt.strftime(date_format)
         except ValueError:
             # ISO format date (YYYY-MM-DDTHH:MM:SS)
-            dt = datetime.datetime.strptime(date_value, ISODATE_FORMAT)
+            dt = parse(date_value)
             return dt.strftime(date_format)
     else:
         return ""

--- a/ckanext/switzerland/helpers/plugin_utils.py
+++ b/ckanext/switzerland/helpers/plugin_utils.py
@@ -11,6 +11,7 @@ import ckanext.switzerland.helpers.localize_utils as ogdch_loc_utils
 import ckanext.switzerland.helpers.terms_of_use_utils as ogdch_term_utils
 import ckanext.switzerland.helpers.format_utils as ogdch_format_utils
 import ckanext.switzerland.helpers.request_utils as ogdch_request_utils
+from dateutil.parser import parse, ParserError
 
 
 def _prepare_suggest_context(search_data, pkg_dict):
@@ -293,9 +294,7 @@ def _transform_package_dates(pkg_dict):
 def _transform_datetime_to_isoformat(value):
     """derive isoformat from datepicker date format"""
     try:
-        date_format = toolkit.config.get(
-            'ckanext.switzerland.date_picker_format', '%d.%m.%Y')
-        d = datetime.datetime.strptime(value, date_format)
+        d = parse(value)
         return d.isoformat()
-    except ValueError:
+    except (TypeError, ParserError):
         return ""

--- a/ckanext/switzerland/helpers/validators.py
+++ b/ckanext/switzerland/helpers/validators.py
@@ -120,10 +120,8 @@ def temporals_to_datetime_output(value):
 
     for temporal in value:
         for key in temporal:
-            if temporal[key]:
+            if temporal[key] is not None:
                 temporal[key] = timestamp_to_date_string(temporal[key])
-            else:
-                temporal[key] = None
     return value
 
 

--- a/ckanext/switzerland/helpers/validators.py
+++ b/ckanext/switzerland/helpers/validators.py
@@ -17,6 +17,8 @@ import json
 import re
 import datetime
 import logging
+from dateutil.parser import parse, ParserError
+
 log = logging.getLogger(__name__)
 
 HARVEST_JUNK = ('__junk',)
@@ -77,13 +79,11 @@ def date_string_to_timestamp(value):
     Necessary as the date form submits dates in this format.
     """
     try:
-        date_format = tk.config.get(
-            'ckanext.switzerland.date_picker_format', '%d.%m.%Y')
-        d = datetime.datetime.strptime(str(value), date_format)
+        d = parse(str(value), dayfirst=True)
         epoch = datetime.datetime(1970, 1, 1)
 
         return int((d - epoch).total_seconds())
-    except ValueError:
+    except (TypeError, ParserError):
         return value
 
 
@@ -123,28 +123,6 @@ def temporals_to_datetime_output(value):
             if temporal[key] is not None:
                 temporal[key] = timestamp_to_date_string(temporal[key])
     return value
-
-
-@scheming_validator
-def ogdch_date_string_format(field, schema):
-    def validator(key, data, errors, context):
-        # if there was an error before calling our validator
-        # don't bother with our validation
-        if errors[key]:
-            return
-        value = data[key]
-        if isinstance(value, int) or len(value) == 0:
-            # A date that is an int has already been converted to a POSIX
-            # timestamp for storage.
-            return
-        if DATE_FORMAT_PATTERN.match(value) is None:
-            # This is the format from the datepicker in the package form.
-            errors[key].append(
-                _('Expecting DD.MM.YYYY, got "%s"') % str(value)
-            )
-            return
-
-    return validator
 
 
 @scheming_validator

--- a/ckanext/switzerland/plugins.py
+++ b/ckanext/switzerland/plugins.py
@@ -68,7 +68,6 @@ class OgdchPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'ogdch_validate_formfield_temporals': ogdch_validators.ogdch_validate_formfield_temporals,  # noqa
             'ogdch_fluent_tags': ogdch_validators.ogdch_fluent_tags,
             'ogdch_temp_scheming_choices': ogdch_validators.ogdch_temp_scheming_choices,  # noqa
-            'ogdch_date_string_format': ogdch_validators.ogdch_date_string_format,  # noqa
         }
 
     # IFacets

--- a/ckanext/switzerland/presets.json
+++ b/ckanext/switzerland/presets.json
@@ -146,7 +146,7 @@
       "values": {
         "display_snippet": "date.html",
         "form_snippet": "date.html",
-        "validators": "scheming_required ogdch_date_string_format date_string_to_timestamp",
+        "validators": "scheming_required date_string_to_timestamp",
         "output_validators": "timestamp_to_date_string"
       }
     },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
+Unidecode==1.0.22
+ckantoolkit==0.0.3
+iribaker==0.1.2
+pandas==0.24.2
+pysolr==3.6.0
+python-dateutil==2.8.1
+pyyaml==5.4
 requests[security]==2.25.1
 urllib3[secure]==1.26.5
-iribaker==0.1.2
-pyyaml==5.4
-ckantoolkit==0.0.3
-pysolr==3.6.0
-Unidecode==1.0.22
-pandas==0.24.2


### PR DESCRIPTION
We have plenty of datasets that might include the date 01.01.1970, which is 0 as a posix timestamp. It should be converted to a date string, not set to None.