### PR TITLE
Catch OverflowError when parsing POSIX date with dateutil

### DIFF
--- a/ckanext/switzerland/helpers/validators.py
+++ b/ckanext/switzerland/helpers/validators.py
@@ -83,7 +83,7 @@ def date_string_to_timestamp(value):
         epoch = datetime.datetime(1970, 1, 1)
 
         return int((d - epoch).total_seconds())
-    except (TypeError, ParserError):
+    except (TypeError, OverflowError, ParserError):
         return value
 
 


### PR DESCRIPTION
Here, we try to parse the date as a string formatted 'DD.MM.YYYY', so we can convert it into POSIX timestamp format. If we get a ParserError it was probably already in POSIX format and we return it as given. If it's a POSIX timestamp that is very large, however (e.g. -3342470400, which is Jan 31 1864), the error given is an OverflowError, so we need to catch that as well.