### PR TITLE
Make frequency DCAT-AP compatible

### DIFF
--- a/ckanext/switzerland/helpers/frontend_helpers.py
+++ b/ckanext/switzerland/helpers/frontend_helpers.py
@@ -79,23 +79,37 @@ def localize_json_facet_title(facet_item):
 
 def get_frequency_name(identifier=None, get_map=False):
     frequencies = OrderedDict([
-        ('http://purl.org/cld/freq/irregular', _('Irregular')),  # noqa
-        ('http://purl.org/cld/freq/continuous', _('Continuous')),  # noqa
-        ('http://purl.org/cld/freq/daily', _('Daily')),  # noqa
-        ('http://purl.org/cld/freq/threeTimesAWeek', _('Three times a week')),  # noqa
-        ('http://purl.org/cld/freq/semiweekly', _('Semi weekly')),  # noqa
-        ('http://purl.org/cld/freq/weekly', _('Weekly')),  # noqa
-        ('http://purl.org/cld/freq/threeTimesAMonth', _('Three times a month')),  # noqa
-        ('http://purl.org/cld/freq/biweekly', _('Biweekly')),  # noqa
-        ('http://purl.org/cld/freq/semimonthly', _('Semimonthly')),  # noqa
-        ('http://purl.org/cld/freq/monthly', _('Monthly')),  # noqa
-        ('http://purl.org/cld/freq/bimonthly', _('Bimonthly')),  # noqa
-        ('http://purl.org/cld/freq/quarterly', _('Quarterly')),  # noqa
-        ('http://purl.org/cld/freq/threeTimesAYear', _('Three times a year')),  # noqa
-        ('http://purl.org/cld/freq/semiannual', _('Semi Annual')),  # noqa
-        ('http://purl.org/cld/freq/annual', _('Annual')),  # noqa
-        ('http://purl.org/cld/freq/biennial', _('Biennial')),  # noqa
-        ('http://purl.org/cld/freq/triennial', _('Triennial')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/OTHER', _('OTHER')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/WEEKLY', _('WEEKLY')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/ANNUAL', _('ANNUAL')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/ANNUAL_2', _('ANNUAL_2')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/ANNUAL_3', _('ANNUAL_3')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/BIENNIAL', _('BIENNIAL')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/BIMONTHLY', _('BIMONTHLY')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/BIWEEKLY', _('BIWEEKLY')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/CONT', _('CONT')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/DAILY', _('DAILY')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/DAILY_2', _('DAILY_2')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/IRREG', _('IRREG')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/MONTHLY', _('MONTHLY')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/MONTHLY_2', _('MONTHLY_2')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/MONTHLY_3', _('MONTHLY_3')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/NEVER', _('NEVER')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/OP_DATPRO', _('OP_DATPRO')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/QUARTERLY', _('QUARTERLY')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/TRIENNIAL', _('TRIENNIAL')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/UNKNOWN', _('UNKNOWN')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/UPDATE_CONT', _('UPDATE_CONT')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/WEEKLY_2', _('WEEKLY_2')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/WEEKLY_3', _('WEEKLY_3')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/QUINQUENNIAL', _('QUINQUENNIAL')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/DECENNIAL', _('DECENNIAL')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/HOURLY', _('HOURLY')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/QUADRENNIAL', _('QUADRENNIAL')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/BIHOURLY', _('BIHOURLY')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/TRIHOURLY', _('TRIHOURLY')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/BIDECENNIAL', _('BIDECENNIAL')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/TRIDECENNIAL', _('TRIDECENNIAL')),  # noqa
     ])
     if get_map:
         return frequencies

--- a/ckanext/switzerland/helpers/frontend_helpers.py
+++ b/ckanext/switzerland/helpers/frontend_helpers.py
@@ -79,37 +79,37 @@ def localize_json_facet_title(facet_item):
 
 def get_frequency_name(identifier=None, get_map=False):
     frequencies = OrderedDict([
-        ('http://publications.europa.eu/resource/authority/frequency/OTHER', _('OTHER')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/WEEKLY', _('WEEKLY')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/ANNUAL', _('ANNUAL')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/ANNUAL_2', _('ANNUAL_2')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/ANNUAL_3', _('ANNUAL_3')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/BIENNIAL', _('BIENNIAL')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/BIMONTHLY', _('BIMONTHLY')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/BIWEEKLY', _('BIWEEKLY')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/CONT', _('CONT')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/DAILY', _('DAILY')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/DAILY_2', _('DAILY_2')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/IRREG', _('IRREG')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/MONTHLY', _('MONTHLY')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/MONTHLY_2', _('MONTHLY_2')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/MONTHLY_3', _('MONTHLY_3')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/NEVER', _('NEVER')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/OP_DATPRO', _('OP_DATPRO')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/QUARTERLY', _('QUARTERLY')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/TRIENNIAL', _('TRIENNIAL')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/UNKNOWN', _('UNKNOWN')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/UPDATE_CONT', _('UPDATE_CONT')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/WEEKLY_2', _('WEEKLY_2')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/WEEKLY_3', _('WEEKLY_3')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/QUINQUENNIAL', _('QUINQUENNIAL')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/DECENNIAL', _('DECENNIAL')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/HOURLY', _('HOURLY')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/QUADRENNIAL', _('QUADRENNIAL')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/BIHOURLY', _('BIHOURLY')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/TRIHOURLY', _('TRIHOURLY')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/BIDECENNIAL', _('BIDECENNIAL')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/TRIDECENNIAL', _('TRIDECENNIAL')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/OTHER', _('other')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/WEEKLY', _('weekly')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/ANNUAL', _('annual')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/ANNUAL_2', _('semiannual')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/ANNUAL_3', _('three times a year')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/BIENNIAL', _('biennial')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/BIMONTHLY', _('bimonthly')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/BIWEEKLY', _('biweekly')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/CONT', _('continuous')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/DAILY', _('daily')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/DAILY_2', _('twice a day')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/IRREG', _('irregular')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/MONTHLY', _('monthly')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/MONTHLY_2', _('semimonthly')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/MONTHLY_3', _('three times a month')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/NEVER', _('never')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/OP_DATPRO', _('Provisional data')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/QUARTERLY', _('quarterly')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/TRIENNIAL', _('triennial')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/UNKNOWN', _('unknown')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/UPDATE_CONT', _('continuously updated')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/WEEKLY_2', _('semiweekly')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/WEEKLY_3', _('three times a week')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/QUINQUENNIAL', _('quinquennial')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/DECENNIAL', _('decennial')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/HOURLY', _('hourly')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/QUADRENNIAL', _('quadrennial')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/BIHOURLY', _('bihourly')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/TRIHOURLY', _('trihourly')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/BIDECENNIAL', _('bidecennial')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/TRIDECENNIAL', _('tridecennial')),  # noqa
     ])
     if get_map:
         return frequencies

--- a/ckanext/switzerland/helpers/frontend_helpers.py
+++ b/ckanext/switzerland/helpers/frontend_helpers.py
@@ -79,37 +79,37 @@ def localize_json_facet_title(facet_item):
 
 def get_frequency_name(identifier=None, get_map=False):
     frequencies = OrderedDict([
-        ('http://publications.europa.eu/resource/authority/frequency/OTHER', _('other')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/WEEKLY', _('weekly')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/ANNUAL', _('annual')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/ANNUAL_2', _('semiannual')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/ANNUAL_3', _('three times a year')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/BIENNIAL', _('biennial')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/BIMONTHLY', _('bimonthly')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/BIWEEKLY', _('biweekly')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/CONT', _('continuous')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/DAILY', _('daily')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/DAILY_2', _('twice a day')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/IRREG', _('irregular')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/MONTHLY', _('monthly')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/MONTHLY_2', _('semimonthly')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/MONTHLY_3', _('three times a month')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/NEVER', _('never')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/OTHER', _('Other')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/WEEKLY', _('Weekly')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/ANNUAL', _('Annual')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/ANNUAL_2', _('Semiannual')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/ANNUAL_3', _('Three times a year')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/BIENNIAL', _('Biennial')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/BIMONTHLY', _('Bimonthly')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/BIWEEKLY', _('Biweekly')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/CONT', _('Continuous')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/DAILY', _('Daily')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/DAILY_2', _('Twice a day')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/IRREG', _('Irregular')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/MONTHLY', _('Monthly')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/MONTHLY_2', _('Semimonthly')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/MONTHLY_3', _('Three times a month')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/NEVER', _('Never')),  # noqa
         ('http://publications.europa.eu/resource/authority/frequency/OP_DATPRO', _('Provisional data')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/QUARTERLY', _('quarterly')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/TRIENNIAL', _('triennial')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/UNKNOWN', _('unknown')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/UPDATE_CONT', _('continuously updated')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/WEEKLY_2', _('semiweekly')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/WEEKLY_3', _('three times a week')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/QUINQUENNIAL', _('quinquennial')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/DECENNIAL', _('decennial')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/HOURLY', _('hourly')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/QUADRENNIAL', _('quadrennial')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/BIHOURLY', _('bihourly')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/TRIHOURLY', _('trihourly')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/BIDECENNIAL', _('bidecennial')),  # noqa
-        ('http://publications.europa.eu/resource/authority/frequency/TRIDECENNIAL', _('tridecennial')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/QUARTERLY', _('Quarterly')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/TRIENNIAL', _('Triennial')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/UNKNOWN', _('Unknown')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/UPDATE_CONT', _('Continuously updated')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/WEEKLY_2', _('Semiweekly')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/WEEKLY_3', _('Three times a week')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/QUINQUENNIAL', _('Quinquennial')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/DECENNIAL', _('Decennial')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/HOURLY', _('Hourly')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/QUADRENNIAL', _('Quadrennial')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/BIHOURLY', _('Bihourly')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/TRIHOURLY', _('Trihourly')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/BIDECENNIAL', _('Bidecennial')),  # noqa
+        ('http://publications.europa.eu/resource/authority/frequency/TRIDECENNIAL', _('Tridecennial')),  # noqa
     ])
     if get_map:
         return frequencies

--- a/ckanext/switzerland/i18n/ckanext-switzerland.pot
+++ b/ckanext/switzerland/i18n/ckanext-switzerland.pot
@@ -229,31 +229,31 @@ msgid ""
 msgstr ""
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:82
-msgid "Irregular"
+msgid "Other"
 msgstr ""
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:83
-msgid "Continuous"
-msgstr ""
-
-#: ckanext/switzerland/helpers/frontend_helpers.py:84
-msgid "Daily"
-msgstr ""
-
-#: ckanext/switzerland/helpers/frontend_helpers.py:85
-msgid "Three times a week"
-msgstr ""
-
-#: ckanext/switzerland/helpers/frontend_helpers.py:86
-msgid "Semi weekly"
-msgstr ""
-
-#: ckanext/switzerland/helpers/frontend_helpers.py:87
 msgid "Weekly"
 msgstr ""
 
+#: ckanext/switzerland/helpers/frontend_helpers.py:84
+msgid "Annual"
+msgstr ""
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:85
+msgid "Semiannual"
+msgstr ""
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:86
+msgid "Three times a year"
+msgstr ""
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:87
+msgid "Biennial"
+msgstr ""
+
 #: ckanext/switzerland/helpers/frontend_helpers.py:88
-msgid "Three times a month"
+msgid "Bimonthly"
 msgstr ""
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:89
@@ -261,39 +261,95 @@ msgid "Biweekly"
 msgstr ""
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:90
-msgid "Semimonthly"
+msgid "Continuous"
 msgstr ""
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:91
-msgid "Monthly"
+msgid "Daily"
 msgstr ""
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:92
-msgid "Bimonthly"
+msgid "Twice a day"
 msgstr ""
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:93
-msgid "Quarterly"
+msgid "Irregular"
 msgstr ""
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:94
-msgid "Three times a year"
+msgid "Monthly"
 msgstr ""
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:95
-msgid "Semi Annual"
+msgid "Semimonthly"
 msgstr ""
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:96
-msgid "Annual"
+msgid "Three times a month"
 msgstr ""
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:97
-msgid "Biennial"
+msgid "Never"
 msgstr ""
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:98
+msgid "Provisional data"
+msgstr ""
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:99
+msgid "Quarterly"
+msgstr ""
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:100
 msgid "Triennial"
+msgstr ""
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:101
+msgid "Unknown"
+msgstr ""
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:102
+msgid "Continuously updated"
+msgstr ""
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:103
+msgid "Semiweekly"
+msgstr ""
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:104
+msgid "Three times a week"
+msgstr ""
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:105
+msgid "Quinquennial"
+msgstr ""
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:106
+msgid "Decennial"
+msgstr ""
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:107
+msgid "Hourly"
+msgstr ""
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:108
+msgid "Quadrennial"
+msgstr ""
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:109
+msgid "Bihourly"
+msgstr ""
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:110
+msgid "Trihourly"
+msgstr ""
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:111
+msgid "Bidecennial"
+msgstr ""
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:112
+msgid "Tridecennial"
 msgstr ""
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:121

--- a/ckanext/switzerland/i18n/de/LC_MESSAGES/ckanext-switzerland.po
+++ b/ckanext/switzerland/i18n/de/LC_MESSAGES/ckanext-switzerland.po
@@ -138,72 +138,128 @@ msgid "Other"
 msgstr "Weitere"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:82
-msgid "Irregular"
-msgstr "Unregelmässig"
+msgid "Other"
+msgstr "Weitere"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:83
-msgid "Continuous"
-msgstr "Kontinuierlich"
-
-#: ckanext/switzerland/helpers/frontend_helpers.py:84
-msgid "Daily"
-msgstr "Täglich"
-
-#: ckanext/switzerland/helpers/frontend_helpers.py:85
-msgid "Three times a week"
-msgstr "Dreimal pro Woche"
-
-#: ckanext/switzerland/helpers/frontend_helpers.py:86
-msgid "Semi weekly"
-msgstr "Halbwöchentlich"
-
-#: ckanext/switzerland/helpers/frontend_helpers.py:87
 msgid "Weekly"
 msgstr "Wöchentlich"
 
-#: ckanext/switzerland/helpers/frontend_helpers.py:88
-msgid "Three times a month"
-msgstr "Dreimal pro Monat"
-
-#: ckanext/switzerland/helpers/frontend_helpers.py:89
-msgid "Biweekly"
-msgstr "Alle zwei Wochen"
-
-#: ckanext/switzerland/helpers/frontend_helpers.py:90
-msgid "Semimonthly"
-msgstr "Halbmonatlich"
-
-#: ckanext/switzerland/helpers/frontend_helpers.py:91
-msgid "Monthly"
-msgstr "Monatlich"
-
-#: ckanext/switzerland/helpers/frontend_helpers.py:92
-msgid "Bimonthly"
-msgstr "Alle zwei Monate"
-
-#: ckanext/switzerland/helpers/frontend_helpers.py:93
-msgid "Quarterly"
-msgstr "Vierteljährlich"
-
-#: ckanext/switzerland/helpers/frontend_helpers.py:94
-msgid "Three times a year"
-msgstr "Dreimal pro Jahr"
-
-#: ckanext/switzerland/helpers/frontend_helpers.py:95
-msgid "Semi Annual"
-msgstr "Halbjährlich"
-
-#: ckanext/switzerland/helpers/frontend_helpers.py:96
+#: ckanext/switzerland/helpers/frontend_helpers.py:84
 msgid "Annual"
 msgstr "Jährlich"
 
-#: ckanext/switzerland/helpers/frontend_helpers.py:97
+#: ckanext/switzerland/helpers/frontend_helpers.py:85
+msgid "Semiannual"
+msgstr "Halbjährlich"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:86
+msgid "Three times a year"
+msgstr "Dreimal im Jahr"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:87
 msgid "Biennial"
 msgstr "Zweijährlich"
 
+#: ckanext/switzerland/helpers/frontend_helpers.py:88
+msgid "Bimonthly"
+msgstr "Zweimonatlich"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:89
+msgid "Biweekly"
+msgstr "Zweiwöchentlich"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:90
+msgid "Continuous"
+msgstr "Kontinuierlich"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:91
+msgid "Daily"
+msgstr "Täglich"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:92
+msgid "Twice a day"
+msgstr "Zweimal täglich"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:93
+msgid "Irregular"
+msgstr "Unregelmässig"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:94
+msgid "Monthly"
+msgstr "Monatlich"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:95
+msgid "Semimonthly"
+msgstr "Zweimal im Monat"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:96
+msgid "Three times a month"
+msgstr "Dreimal im Monat"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:97
+msgid "Never"
+msgstr "Niemals"
+
 #: ckanext/switzerland/helpers/frontend_helpers.py:98
+msgid "Provisional data"
+msgstr "Vorläufige Daten"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:99
+msgid "Quarterly"
+msgstr "Vierteljährlich"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:100
 msgid "Triennial"
 msgstr "Dreijährlich"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:101
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:102
+msgid "Continuously updated"
+msgstr "Ständige Aktualisierung"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:103
+msgid "Semiweekly"
+msgstr "Zweimal in Woche"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:104
+msgid "Three times a week"
+msgstr "Dreimal in Woche"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:105
+msgid "Quinquennial"
+msgstr "Fünfjährlich"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:106
+msgid "Decennial"
+msgstr "Alle zehn Jahre"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:107
+msgid "Hourly"
+msgstr "Stündlich"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:108
+msgid "Quadrennial"
+msgstr "Vierjährlich"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:109
+msgid "Bihourly"
+msgstr "Alle zwei Stunden"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:110
+msgid "Trihourly"
+msgstr "Alle drei Stunden"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:111
+msgid "Bidecennial"
+msgstr "Alle zwanzig Jahre"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:112
+msgid "Tridecennial"
+msgstr "Alle dreißig Jahre"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:121
 msgid "Open use"

--- a/ckanext/switzerland/i18n/de/LC_MESSAGES/ckanext-switzerland.po
+++ b/ckanext/switzerland/i18n/de/LC_MESSAGES/ckanext-switzerland.po
@@ -259,7 +259,7 @@ msgstr "Alle zwanzig Jahre"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:112
 msgid "Tridecennial"
-msgstr "Alle dreißig Jahre"
+msgstr "Alle dreissig Jahre"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:121
 msgid "Open use"

--- a/ckanext/switzerland/i18n/fr/LC_MESSAGES/ckanext-switzerland.po
+++ b/ckanext/switzerland/i18n/fr/LC_MESSAGES/ckanext-switzerland.po
@@ -139,72 +139,128 @@ msgid "Other"
 msgstr "Autre"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:82
-msgid "Irregular"
-msgstr "Irrégulier"
+msgid "Other"
+msgstr "Autre"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:83
-msgid "Continuous"
-msgstr "Continu"
+msgid "Weekly"
+msgstr "Hebdomadaire"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:84
-msgid "Daily"
-msgstr "1 fois par jour"
+msgid "Annual"
+msgstr "Annuel"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:85
-msgid "Three times a week"
-msgstr "3 fois par semaine"
+msgid "Semiannual"
+msgstr "Semestriel"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:86
-msgid "Semi weekly"
-msgstr "2 fois par semaine"
+msgid "Three times a year"
+msgstr "Trois fois par an"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:87
-msgid "Weekly"
-msgstr "1 fois par semaine"
+msgid "Biennial"
+msgstr "Biennal"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:88
-msgid "Three times a month"
-msgstr "3 fois par mois"
+msgid "Bimonthly"
+msgstr "Bimestriel"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:89
 msgid "Biweekly"
-msgstr "Toutes les 2 semaines"
+msgstr "Tous les quinze jours"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:90
-msgid "Semimonthly"
-msgstr "2 fois par mois"
+msgid "Continuous"
+msgstr "Continuel"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:91
-msgid "Monthly"
-msgstr "1 fois par mois"
+msgid "Daily"
+msgstr "Quotidien"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:92
-msgid "Bimonthly"
-msgstr "Tous les 2 mois"
+msgid "Twice a day"
+msgstr "Deux fois par jour"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:93
-msgid "Quarterly"
-msgstr "1 fois par trimestre"
+msgid "Irregular"
+msgstr "Irrégulier"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:94
-msgid "Three times a year"
-msgstr "3 fois par an"
+msgid "Monthly"
+msgstr "Mensuel"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:95
-msgid "Semi Annual"
-msgstr "2 fois par an"
+msgid "Semimonthly"
+msgstr "Bimensuel"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:96
-msgid "Annual"
-msgstr "1 fois par an"
+msgid "Three times a month"
+msgstr "Trois fois par mois"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:97
-msgid "Biennial"
-msgstr "Tous les 2 ans"
+msgid "Never"
+msgstr "Jamais"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:98
+msgid "Provisional data"
+msgstr "Données provisoires"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:99
+msgid "Quarterly"
+msgstr "Trimestriel"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:100
 msgid "Triennial"
-msgstr "Tous les 3 ans"
+msgstr "Triennal"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:101
+msgid "Unknown"
+msgstr "Inconnu"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:102
+msgid "Continuously updated"
+msgstr "Mise à jour continuelle"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:103
+msgid "Semiweekly"
+msgstr "Bihebdomadaire"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:104
+msgid "Three times a week"
+msgstr "Trois fois par semaine"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:105
+msgid "Quinquennial"
+msgstr "Tous les cinq ans"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:106
+msgid "Decennial"
+msgstr "Tous les dix ans"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:107
+msgid "Hourly"
+msgstr "Toutes les heures"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:108
+msgid "Quadrennial"
+msgstr "Tous les quatre ans"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:109
+msgid "Bihourly"
+msgstr "Toutes les deux heures"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:110
+msgid "Trihourly"
+msgstr "Toutes les trois heures"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:111
+msgid "Bidecennial"
+msgstr "Tous les vingt ans"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:112
+msgid "Tridecennial"
+msgstr "Tous les trente ans"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:121
 msgid "Open use"

--- a/ckanext/switzerland/i18n/it/LC_MESSAGES/ckanext-switzerland.po
+++ b/ckanext/switzerland/i18n/it/LC_MESSAGES/ckanext-switzerland.po
@@ -138,72 +138,128 @@ msgid "Other"
 msgstr "Altro"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:82
-msgid "Irregular"
-msgstr "Irregolarmente"
+msgid "Other"
+msgstr "Altro"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:83
-msgid "Continuous"
-msgstr "Continuamente"
+msgid "Weekly"
+msgstr "Settimanale"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:84
-msgid "Daily"
-msgstr "Giornalmente"
+msgid "Annual"
+msgstr "Annuale"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:85
-msgid "Three times a week"
-msgstr "Tre volte la settimana"
+msgid "Semiannual"
+msgstr "Semestrale"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:86
-msgid "Semi weekly"
-msgstr "Due volte la settimana"
+msgid "Three times a year"
+msgstr "Tre volte all'anno"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:87
-msgid "Weekly"
-msgstr "Settimanalmente"
+msgid "Biennial"
+msgstr "Biennale"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:88
-msgid "Three times a month"
-msgstr "Tre volte il mese"
+msgid "Bimonthly"
+msgstr "Bimestrale"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:89
 msgid "Biweekly"
-msgstr "Ogni due settimane"
+msgstr "Quindicinale"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:90
-msgid "Semimonthly"
-msgstr "Due volte il mese"
+msgid "Continuous"
+msgstr "Continuo"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:91
-msgid "Monthly"
-msgstr "Mensilmente"
+msgid "Daily"
+msgstr "Quotidiano"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:92
-msgid "Bimonthly"
-msgstr "Ogni due mesi"
+msgid "Twice a day"
+msgstr "Due volte al giorno"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:93
-msgid "Quarterly"
-msgstr "Trimestralmente"
+msgid "Irregular"
+msgstr "Irregolare"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:94
-msgid "Three times a year"
-msgstr "Tre volte l'anno"
+msgid "Monthly"
+msgstr "Mensile"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:95
-msgid "Semi Annual"
-msgstr "Due volte l'anno"
+msgid "Semimonthly"
+msgstr "Bimensile"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:96
-msgid "Annual"
-msgstr "Annualmente"
+msgid "Three times a month"
+msgstr "Tre volte al mese"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:97
-msgid "Biennial"
-msgstr "Ogni due anni"
+msgid "Never"
+msgstr "Mai"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:98
+msgid "Provisional data"
+msgstr "Dati provvisori"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:99
+msgid "Quarterly"
+msgstr "Trimestrale"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:100
 msgid "Triennial"
-msgstr "Ogni tre anni"
+msgstr "Triennale"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:101
+msgid "Unknown"
+msgstr "Sconosciuto"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:102
+msgid "Continuously updated"
+msgstr "In continuo aggiornamento"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:103
+msgid "Semiweekly"
+msgstr "Bisettimanale"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:104
+msgid "Three times a week"
+msgstr "Tre volte a settimana"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:105
+msgid "Quinquennial"
+msgstr "Ogni cinque anni"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:106
+msgid "Decennial"
+msgstr "Decennale"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:107
+msgid "Hourly"
+msgstr "Ogni ora"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:108
+msgid "Quadrennial"
+msgstr "Ogni quattro anni"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:109
+msgid "Bihourly"
+msgstr "Ogni due ore"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:110
+msgid "Trihourly"
+msgstr "Ogni tre ore"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:111
+msgid "Bidecennial"
+msgstr "Bidecennale"
+
+#: ckanext/switzerland/helpers/frontend_helpers.py:112
+msgid "Tridecennial"
+msgstr "Tridecennale"
 
 #: ckanext/switzerland/helpers/frontend_helpers.py:121
 msgid "Open use"


### PR DESCRIPTION
Store EU frequency uris and values (http://publications.europa.eu/resource/authority/frequency)
instead of URLS of the DCAT vocabulary:  http://purl.org/cld/freq 