### PR TITLE
enable travis on branch conformance sprint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: trusty
 branches:
   only:
     - "master"
+    - "conformance-sprint"
 
 language: python
 


### PR DESCRIPTION
this branch is used to integrate the work done on the dcat conformance sprint