### PR TITLE
fix: Handle missing titles/descriptions when indexing datasets

### DIFF
--- a/ckanext/switzerland/helpers/localize_utils.py
+++ b/ckanext/switzerland/helpers/localize_utils.py
@@ -31,7 +31,7 @@ def parse_json(value, default_value=None):
 
 def lang_to_string(data_dict, attribute):
     """make a long string with all 4 languages of an attribute"""
-    value_dict = data_dict.get(attribute)
+    value_dict = data_dict.get(attribute, {})
     return ('%s - %s - %s - %s' % (
         value_dict.get('de', ''),
         value_dict.get('fr', ''),


### PR DESCRIPTION
This util function is called on dataset titles and descriptions, and resource titles and descriptions, when preparing a dataset for indexing.If the dataset or resource does not have an
attribute 'title' or 'description', we should return an empty dict instead of None, so that calling value_dict.get() will not throw an error.