### PR TITLE
feat: Display all organizations when JS is not enabled

### DIFF
--- a/ckanext/switzerland/templates/organization/snippets/organization_list.html
+++ b/ckanext/switzerland/templates/organization/snippets/organization_list.html
@@ -7,7 +7,7 @@ Example:
     {% snippet "organization/snippets/organization_list.html" %}
 
 #}
-<div id="publisher-tree">
+<div id="publisher-tree" class="empty-search">
   {# we use ogdch_render_tree instead of the organization_tree template to speed up the rendering #}
   {% if c.q %}
     {{ h.ogdch_render_tree(organizations)|safe }}


### PR DESCRIPTION
The publisher tree that is rendered here was previously not displayed by default, as specified in ogdch_organization_filter.css.
The data-module ogdch_organization_filter.js then added a 'match' or 'childmatch' class to all organizations that matched the
given search term, displaying only those organizations. The disadvantage of this approach was that, when JavaScript was disabled
(as is the case on the networks of some of our data publishers), no organizations were shown at all.

Adding the class 'empty-search' to the publisher tree when the page is first loaded means that it is displayed. If JS is available,
the class will be removed from the tree on first typing into the search bar, as usual. Without JS, the organizations are shown
and non-interactive search functions as usual (i.e. the user enters their search term and clicks/presses return to go to a separate
page of results).