### PR TITLE
feat: adapt solr indexing to set date fields

### DIFF
--- a/ckanext/switzerland/helpers/date_helpers.py
+++ b/ckanext/switzerland/helpers/date_helpers.py
@@ -130,7 +130,8 @@ def get_latest_isodate(resource_dates):
     """
     if not resource_dates:
         return ''
-    isodates = [transform_any_date_to_isodate(date_field) for date_field in resource_dates]
+    isodates = [transform_any_date_to_isodate(date_field)
+                for date_field in resource_dates]
     latest_isoodate = max(isodates)
     return latest_isoodate
 

--- a/ckanext/switzerland/helpers/date_helpers.py
+++ b/ckanext/switzerland/helpers/date_helpers.py
@@ -132,8 +132,8 @@ def get_latest_isodate(resource_dates):
         return ''
     isodates = [transform_any_date_to_isodate(date_field)
                 for date_field in resource_dates]
-    latest_isoodate = max(isodates)
-    return latest_isoodate
+    latest_isodate = max(isodates)
+    return latest_isodate
 
 
 def correct_invalid_empty_date(value):

--- a/ckanext/switzerland/helpers/date_helpers.py
+++ b/ckanext/switzerland/helpers/date_helpers.py
@@ -106,6 +106,27 @@ def display_if_datetime(value):
         return None
 
 
+def transform_any_date_to_isodate(date_field):
+    isodate_field = store_if_ogdch_date(date_field)
+    if isodate_field:
+        return isodate_field
+    isodate_field = store_if_isodate(date_field)
+    if isodate_field:
+        return isodate_field
+    isodate_field = store_if_timestamp(date_field)
+    if isodate_field:
+        return isodate_field
+
+
+def get_latest_isodate(resource_dates):
+    """return the latest date of a list of isodates"""
+    if not resource_dates:
+        return ''
+    isodates = [transform_any_date_to_isodate(date_field) for date_field in resource_dates]
+    latest_isoodate = max(isodates)
+    return latest_isoodate
+
+
 def correct_invalid_empty_date(value):
     """date values stored in postgres as not set"""
     if value == INVALID_EMPTY_DATE:

--- a/ckanext/switzerland/helpers/date_helpers.py
+++ b/ckanext/switzerland/helpers/date_helpers.py
@@ -107,6 +107,10 @@ def display_if_datetime(value):
 
 
 def transform_any_date_to_isodate(date_field):
+    """transform any stored date format into an isodate:
+    considered are the ogdch_date_format, timestamps
+    and isodates.
+    """
     isodate_field = store_if_ogdch_date(date_field)
     if isodate_field:
         return isodate_field
@@ -119,7 +123,11 @@ def transform_any_date_to_isodate(date_field):
 
 
 def get_latest_isodate(resource_dates):
-    """return the latest date of a list of isodates"""
+    """return the latest date of a list of resource dates:
+    the dates are all transformed into isodates,
+    then a stringcomparison will bring back the
+    latest of those dates
+    """
     if not resource_dates:
         return ''
     isodates = [transform_any_date_to_isodate(date_field) for date_field in resource_dates]

--- a/ckanext/switzerland/helpers/plugin_utils.py
+++ b/ckanext/switzerland/helpers/plugin_utils.py
@@ -82,7 +82,6 @@ def _is_dataset_package_type(pkg_dict):
 
 def ogdch_prepare_search_data_for_index(search_data):  # noqa
     """prepares the data for indexing"""
-    log.error("NOW INDEXING")
     if not _is_dataset_package_type(search_data):
         return search_data
 
@@ -112,8 +111,6 @@ def ogdch_prepare_search_data_for_index(search_data):  # noqa
     search_data['res_latest_modified'] = ogdch_date_utils.get_latest_isodate(
         [(r['modified']) for r in validated_dict[u'resources'] if 'modified' in r.keys()]
     )
-    log.error(search_data['res_latest_issued'])
-    log.error(search_data['res_latest_modified'])
     search_data['linked_data'] = ogdch_format_utils.prepare_formats_for_index(
         resources=validated_dict[u'resources'],
         linked_data_only=True

--- a/ckanext/switzerland/helpers/plugin_utils.py
+++ b/ckanext/switzerland/helpers/plugin_utils.py
@@ -106,10 +106,14 @@ def ogdch_prepare_search_data_for_index(search_data):  # noqa
     )
     search_data['res_rights'] = [ogdch_term_utils.simplify_terms_of_use(r['rights']) for r in validated_dict[u'resources'] if 'rights' in r.keys()]  # noqa
     search_data['res_latest_issued'] = ogdch_date_utils.get_latest_isodate(
-        [(r['issued']) for r in validated_dict[u'resources'] if 'issued' in r.keys()]
+        [(r['issued'])
+         for r in validated_dict[u'resources']
+         if 'issued' in r.keys()]
     )
     search_data['res_latest_modified'] = ogdch_date_utils.get_latest_isodate(
-        [(r['modified']) for r in validated_dict[u'resources'] if 'modified' in r.keys()]
+        [(r['modified'])
+         for r in validated_dict[u'resources']
+         if 'modified' in r.keys()]
     )
     search_data['linked_data'] = ogdch_format_utils.prepare_formats_for_index(
         resources=validated_dict[u'resources'],

--- a/ckanext/switzerland/helpers/plugin_utils.py
+++ b/ckanext/switzerland/helpers/plugin_utils.py
@@ -12,6 +12,7 @@ import ckanext.switzerland.helpers.localize_utils as ogdch_loc_utils
 import ckanext.switzerland.helpers.terms_of_use_utils as ogdch_term_utils
 import ckanext.switzerland.helpers.format_utils as ogdch_format_utils
 import ckanext.switzerland.helpers.request_utils as ogdch_request_utils
+import ckanext.switzerland.helpers.date_helpers as ogdch_date_utils
 from datetime import datetime
 
 log = logging.getLogger(__name__)
@@ -81,6 +82,7 @@ def _is_dataset_package_type(pkg_dict):
 
 def ogdch_prepare_search_data_for_index(search_data):  # noqa
     """prepares the data for indexing"""
+    log.error("NOW INDEXING")
     if not _is_dataset_package_type(search_data):
         return search_data
 
@@ -104,6 +106,10 @@ def ogdch_prepare_search_data_for_index(search_data):  # noqa
         resources=validated_dict[u'resources']
     )
     search_data['res_rights'] = [ogdch_term_utils.simplify_terms_of_use(r['rights']) for r in validated_dict[u'resources'] if 'rights' in r.keys()]  # noqa
+    search_data['res_latest_issued'] = ogdch_date_utils.get_latest_isodate([(r['issued']) for r in validated_dict[u'resources'] if 'issued' in r.keys()])  # noqa
+    search_data['res_latest_modified'] = ogdch_date_utils.get_latest_isodate([(r['modified']) for r in validated_dict[u'resources'] if 'modified' in r.keys()])  # noqa
+    log.error(search_data['res_latest_issued'])
+    log.error(search_data['res_latest_modified'])
     search_data['linked_data'] = ogdch_format_utils.prepare_formats_for_index(
         resources=validated_dict[u'resources'],
         linked_data_only=True

--- a/ckanext/switzerland/helpers/plugin_utils.py
+++ b/ckanext/switzerland/helpers/plugin_utils.py
@@ -106,8 +106,12 @@ def ogdch_prepare_search_data_for_index(search_data):  # noqa
         resources=validated_dict[u'resources']
     )
     search_data['res_rights'] = [ogdch_term_utils.simplify_terms_of_use(r['rights']) for r in validated_dict[u'resources'] if 'rights' in r.keys()]  # noqa
-    search_data['res_latest_issued'] = ogdch_date_utils.get_latest_isodate([(r['issued']) for r in validated_dict[u'resources'] if 'issued' in r.keys()])  # noqa
-    search_data['res_latest_modified'] = ogdch_date_utils.get_latest_isodate([(r['modified']) for r in validated_dict[u'resources'] if 'modified' in r.keys()])  # noqa
+    search_data['res_latest_issued'] = ogdch_date_utils.get_latest_isodate(
+        [(r['issued']) for r in validated_dict[u'resources'] if 'issued' in r.keys()]
+    )
+    search_data['res_latest_modified'] = ogdch_date_utils.get_latest_isodate(
+        [(r['modified']) for r in validated_dict[u'resources'] if 'modified' in r.keys()]
+    )
     log.error(search_data['res_latest_issued'])
     log.error(search_data['res_latest_modified'])
     search_data['linked_data'] = ogdch_format_utils.prepare_formats_for_index(


### PR DESCRIPTION
issued and modified of the dataset are already set by ckan

res_latest_issued and res_latest_modified are set by the latest of these dates over all resources of a dataset

the resource dates need first to be transformed into isodates after that the maximum over the resulting string values will be the latest date