### PR TITLE
Add limitation on API requests to add showcases

### DIFF
--- a/ckanext/switzerland/helpers/request_utils.py
+++ b/ckanext/switzerland/helpers/request_utils.py
@@ -6,6 +6,7 @@ from backoff import on_exception, expo
 
 FIVE_MINUTES = 300
 
+
 def get_content_headers(url):
     response = requests.head(url)
     return response

--- a/ckanext/switzerland/plugins.py
+++ b/ckanext/switzerland/plugins.py
@@ -506,7 +506,6 @@ class OgdchShowcasePlugin(ShowcasePlugin):
         if response:
             return 'showcase/new.html'
 
-
     def _modify_package_schema(self, schema):
         schema.update(
             {

--- a/ckanext/switzerland/plugins.py
+++ b/ckanext/switzerland/plugins.py
@@ -500,6 +500,13 @@ class OgdchShowcasePlugin(ShowcasePlugin):
 
     # IDatasetForm
 
+    def new_template(self):
+        base_url = toolkit.request.url
+        response = ogdch_request_utils.set_call_api_limit(base_url)
+        if response:
+            return 'showcase/new.html'
+
+
     def _modify_package_schema(self, schema):
         schema.update(
             {

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ requests[security]==2.25.1
 urllib3[secure]==1.26.5
 isodate==0.6.1
 rdflib==5.0.0
+ratelimit==2.2.1
+backoff==1.11.1


### PR DESCRIPTION
It is not allowed to make requests to add showcases ofter than 2 times per 5 minutes.
If so we will get: RateLimitException: too many calls 