### PR TITLE
feat: add custom api route to submit showcases

### DIFF
--- a/ckanext/switzerland/logic.py
+++ b/ckanext/switzerland/logic.py
@@ -299,6 +299,30 @@ def ogdch_showcase_search(context, data_dict):
 
 
 @side_effect_free
+def ogdch_showcase_submit(context, data_dict):
+    '''
+    Custom logic to create a showcase. Showcases can be submitted
+    from the frontend and should be created in one step along with
+    all the datasets that are attached to the showcase.
+    '''
+    try:
+        showcase = tk.get_action('ckanext_showcase_create')(
+            context, data_dict
+        )
+        package_association_data_dict = {'showcase_id': showcase['id']}
+        datasets = data_dict.get('datasets')
+        if datasets:
+            for package_id in datasets:
+                package_association_data_dict['package_id'] = package_id
+                tk.get_action('ckanext_showcase_package_association_create')(
+                    context, package_association_data_dict
+                )
+        return showcase
+    except ValidationError:
+        raise
+
+
+@side_effect_free
 def ogdch_harvest_monitor(context, data_dict):
     """Returns the status of the fetch and gather processes.
 

--- a/ckanext/switzerland/logic.py
+++ b/ckanext/switzerland/logic.py
@@ -298,7 +298,6 @@ def ogdch_showcase_search(context, data_dict):
         raise NotFound
 
 
-@side_effect_free
 def ogdch_showcase_submit(context, data_dict):
     '''
     Custom logic to create a showcase. Showcases can be submitted

--- a/ckanext/switzerland/plugins.py
+++ b/ckanext/switzerland/plugins.py
@@ -127,6 +127,7 @@ class OgdchPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'ogdch_add_users_to_groups': ogdch_logic.ogdch_add_users_to_groups,
             'user_create': ogdch_logic.ogdch_user_create,
             'ogdch_harvest_monitor': ogdch_logic.ogdch_harvest_monitor,
+            'ogdch_showcase_submit': ogdch_logic.ogdch_showcase_submit,
         }
 
     # ITemplateHelpers


### PR DESCRIPTION
the frontend submits showcases along with datasets: the showcase should be submitted in one go from the frontend, whereas in the backend the showcase submission takes several steps: first the showcase is created, after that for each submitted package a connection to the package is created