### PR TITLE
Add API route to get subscription details

### DIFF
--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -137,6 +137,12 @@ python setup.py develop
 pip install -r requirements.txt
 pip install -r dev-requirements.txt
 
+echo "Installing ckanext-subscribe..."
+git clone https://github.com/opendata-swiss/ckanext-subscribe.git
+cd ckanext-subscribe
+python setup.py develop
+cd -
+
 echo "Moving test.ini into a subdir..."
 mkdir subdir
 mv test.ini subdir

--- a/ckanext/switzerland/logic.py
+++ b/ckanext/switzerland/logic.py
@@ -10,7 +10,7 @@ import rdflib
 import rdflib.parser
 from rdflib.namespace import Namespace, RDF
 
-from ckan.common import config, json
+from ckan.common import config
 from ckan.plugins.toolkit import get_or_bust, side_effect_free
 from ckan.logic import ActionError, NotFound, ValidationError
 import ckan.plugins.toolkit as tk
@@ -33,6 +33,7 @@ from ckan.lib.munge import munge_title_to_name
 from ckanext.subscribe import dictization
 from ckanext.subscribe.utils import get_email_vars
 from ckanext.subscribe.model import Subscription, Frequency
+from ckanext.subscribe.email_auth import authenticate_with_code
 
 import logging
 
@@ -543,13 +544,13 @@ def ogdch_user_create(context, data_dict):
 def ogdch_subscribe_manage(context, data_dict):
     '''Request a code for managing existing subscriptions. Causes a email to be
     sent, containing a manage link.
-    :returns: json
+    :returns: list of dictionaries
     '''
     
-    #data_dict includes only code {'code': u'mG7iL4VnFrY02IkWcS0YZHkRHZlvxZpW'}
-    #log.info(get_email_vars(code=data_dict['code'])) # to get email
-    
-    data_dict['email'] = "nata@cats.com"
+    data_dict['email'] = authenticate_with_code(data_dict['code'])
+    if not data_dict['email']:
+        raise Exception("The email is not valid")
+        
     email = get_or_bust(data_dict, 'email')
     model = context['model']
     
@@ -571,7 +572,7 @@ def ogdch_subscribe_manage(context, data_dict):
         subscriptions.append(subscription)
         
         
-    return json.dumps(subscriptions)      
+    return subscriptions    
         
     
     

--- a/ckanext/switzerland/logic.py
+++ b/ckanext/switzerland/logic.py
@@ -540,7 +540,6 @@ def ogdch_user_create(context, data_dict):
     return user
 
 
-@side_effect_free
 def ogdch_subscribe_manage(context, data_dict):
     '''Request a code for managing existing subscriptions. Causes a email to be
     sent, containing a manage link.
@@ -553,7 +552,6 @@ def ogdch_subscribe_manage(context, data_dict):
         
     email = get_or_bust(data_dict, 'email')
     model = context['model']
-    
     subscription_objs = \
         model.Session.query(Subscription, model.Package, model.Group) \
             .filter_by(email=email) \
@@ -566,15 +564,8 @@ def ogdch_subscribe_manage(context, data_dict):
         subscription = \
             dictization.dictize_subscription(subscription_obj, context)
         # add information about dataset
-        subscription['dataset_id'] = package.id
-        subscription['dataset_name'] = package.name
-        
+        subscription['object_name'] = package.name
         subscriptions.append(subscription)
-        
         
     return subscriptions    
         
-    
-    
-    
-    

--- a/ckanext/switzerland/logic.py
+++ b/ckanext/switzerland/logic.py
@@ -546,7 +546,7 @@ def ogdch_subscribe_manage(context, data_dict):
         data_dict['email'] = authenticate_with_code(data_dict['code'])
     except ValueError:
         raise ValidationError("Code is not valid")
-        
+
     if not data_dict['email']:
         raise Exception("The email is not valid")
 

--- a/ckanext/switzerland/logic.py
+++ b/ckanext/switzerland/logic.py
@@ -540,24 +540,23 @@ def ogdch_user_create(context, data_dict):
 
 
 def ogdch_subscribe_manage(context, data_dict):
-    '''Request a code for managing existing subscriptions. Causes a email to be
-    sent, containing a manage link.
+    """Request a code to get information about existing subscriptions.
     :returns: list of dictionaries
-    '''
-    
+    """
+
     data_dict['email'] = authenticate_with_code(data_dict['code'])
     if not data_dict['email']:
         raise Exception("The email is not valid")
-        
+
     email = get_or_bust(data_dict, 'email')
     model = context['model']
     subscription_objs = \
-        model.Session.query(Subscription, model.Package, model.Group) \
-            .filter_by(email=email) \
-            .outerjoin(model.Package, Subscription.object_id == model.Package.id) \
-            .outerjoin(model.Group, Subscription.object_id == model.Group.id) \
-            .all()
-    
+        model.Session.query(Subscription, model.Package, model.Group)\
+        .filter_by(email=email)\
+        .outerjoin(model.Package, Subscription.object_id == model.Package.id)\
+        .outerjoin(model.Group, Subscription.object_id == model.Group.id)\
+        .all()
+
     subscriptions = []
     for subscription_obj, package, group in subscription_objs:
         subscription = \
@@ -565,6 +564,5 @@ def ogdch_subscribe_manage(context, data_dict):
         # add information about dataset
         subscription['object_name'] = package.name
         subscriptions.append(subscription)
-        
-    return subscriptions    
-        
+
+    return subscriptions

--- a/ckanext/switzerland/logic.py
+++ b/ckanext/switzerland/logic.py
@@ -31,8 +31,7 @@ from ckanext.switzerland.helpers.logic_helpers import (
     map_existing_resources_to_new_dataset)
 from ckan.lib.munge import munge_title_to_name
 from ckanext.subscribe import dictization
-from ckanext.subscribe.utils import get_email_vars
-from ckanext.subscribe.model import Subscription, Frequency
+from ckanext.subscribe.model import Subscription
 from ckanext.subscribe.email_auth import authenticate_with_code
 
 import logging

--- a/ckanext/switzerland/plugins.py
+++ b/ckanext/switzerland/plugins.py
@@ -128,6 +128,7 @@ class OgdchPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'user_create': ogdch_logic.ogdch_user_create,
             'ogdch_harvest_monitor': ogdch_logic.ogdch_harvest_monitor,
             'ogdch_showcase_submit': ogdch_logic.ogdch_showcase_submit,
+            'ogdch_subscribe_manage': ogdch_logic.ogdch_subscribe_manage,
         }
 
     # ITemplateHelpers


### PR DESCRIPTION
The frontend sends a request to CKAN, e.g. https://ckan.opendata.swiss/api/3/action/ogdch_subscribe_manage?code=[32-character-code] 
and gets back a, e.g., JSON object with the subscription data for that email address