### PR TITLE
feat: Add two API routes for dataset subscriptions

### DIFF
--- a/ckanext/switzerland/plugins.py
+++ b/ckanext/switzerland/plugins.py
@@ -131,6 +131,8 @@ class OgdchPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'ogdch_harvest_monitor': ogdch_logic.ogdch_harvest_monitor,
             'ogdch_showcase_submit': ogdch_logic.ogdch_showcase_submit,
             'ogdch_subscribe_manage': ogdch_logic.ogdch_subscribe_manage,
+            'ogdch_subscribe_unsubscribe': ogdch_logic.ogdch_subscribe_unsubscribe,  # noqa
+            'ogdch_subscribe_unsubscribe_all': ogdch_logic.ogdch_subscribe_unsubscribe_all,  # noqa
         }
 
     # ITemplateHelpers


### PR DESCRIPTION
The ckanext-subscribe actions expect the user's email address as well as the auth code, which we don't have when calling these routes from the frontend.