### PR TITLE
feat: Remove manage link from verification email

### DIFF
--- a/ckanext/switzerland/templates/emails/subscribe_verification.html
+++ b/ckanext/switzerland/templates/emails/subscribe_verification.html
@@ -41,10 +41,6 @@
     </a>
 </p>
 
-<p>
-    <a href="{{ manage_link }}">Mein Abonnement verwalten</a>
-</p>
-
 --
 
 <p>Bonjour</p>
@@ -84,10 +80,6 @@
         <img src="https://opendata.swiss/images/twitter.svg" alt="Twitter"
              style="color: #fff; background-color: #009688; border: 0;"/>
     </a>
-</p>
-
-<p>
-    <a href="{{ manage_link }}">Gérer mes abonnements</a>
 </p>
 
 --
@@ -130,10 +122,6 @@
     </a>
 </p>
 
-<p>
-    <a href="{{ manage_link }}">Manage my subscriptions</a>
-</p>
-
 --
 
 <p>Buongiorno,</p>
@@ -172,9 +160,5 @@
         <img src="https://opendata.swiss/images/twitter.svg" alt="Twitter"
              style="color: #fff; background-color: #009688; border: 0;"/>
     </a>
-</p>
-
-<p>
-    <a href="{{ manage_link }}">Gestione abbonamento</a>
 </p>
 </body>

--- a/ckanext/switzerland/templates/emails/subscribe_verification_plain_text.txt
+++ b/ckanext/switzerland/templates/emails/subscribe_verification_plain_text.txt
@@ -20,8 +20,6 @@ Espace de l'Europe 10
 CH-2010 Neuchâtel
 www.bfs.admin.ch/ogd
 
-Mein Abonnement verwalten: {{ manage_link }}
-
 --
 
 Bonjour
@@ -45,8 +43,6 @@ Office fédéral de la statistique
 Espace de l'Europe 10
 CH-2010 Neuchâtel
 <a href="www.bfs.admin.ch/ogd">www.bfs.admin.ch/ogd</a>
-
-Gérer mes abonnements: {{ manage_link }}
 
 --
 
@@ -72,8 +68,6 @@ Espace de l'Europe 10
 CH-2010 Neuchâtel
 <a href="www.bfs.admin.ch/ogd">www.bfs.admin.ch/ogd</a>
 
-Manage my subscriptions: {{ manage_link }}
-
 --
 
 Buongiorno,
@@ -97,5 +91,3 @@ Ufficio federale di statistica UST
 Espace de l’Europe 10,
 CH-2010 Neuchâtel
 <a href="www.bfs.admin.ch/ogd">www.bfs.admin.ch/ogd</a>
-
-Gestione abbonamento: {{ manage_link }}

--- a/ckanext/switzerland/templates/subscribe/manage.html
+++ b/ckanext/switzerland/templates/subscribe/manage.html
@@ -57,7 +57,7 @@
 
   <form method='post' action="{{ h.url_for(controller='ckanext.subscribe.controller:SubscribeController', action='unsubscribe_all') }}" id="unsubscribe-all" enctype="multipart/form-data" class="form-inline">
     <!-- (Bootstrap 3) <div class="form-group input-group-sm"> -->
-      <input id="unsubscribe-code" type="hidden" name="code" value="{{ code }}" />
+      <input id="unsubscribe-all-code" type="hidden" name="code" value="{{ code }}" />
     <!-- </div> -->
     <button type="submit" class="btn btn-default" name="save">{{ _('Unsubscribe all') }}</button>
   </form>

--- a/ckanext/switzerland/templates/subscribe/manage.html
+++ b/ckanext/switzerland/templates/subscribe/manage.html
@@ -1,9 +1,4 @@
-{% extends "page.html" %}
-
-{% block styles %}
-  {{ super() }}
-  {% resource 'subscribe/subscribe.css' %}
-{% endblock styles %}
+{% ckan_extends %}
 
 {% block primary %}
 <article class="module">
@@ -16,9 +11,10 @@
 {% if subscriptions %}
   <table id="subscriptions">
     {% for subscription in subscriptions %}
+      {% set title = h.get_localized_value_for_display(subscription.object_title) %}
       <tr>
         <td>{{ subscription.object_type |capitalize }}</td>
-        <td><a href="{{ subscription.object_link }}">{{ subscription.object_title }}</a></td>
+        <td><a href="{{ subscription.object_link }}">{{ title }}</a></td>
         <td>
           {% if not subscription.verified %}Unverified{% endif %}
         </td>
@@ -73,5 +69,3 @@
   </div>
 </article>
 {% endblock %}
-
-{% block secondary %}{% endblock %}

--- a/ckanext/switzerland/templates/subscribe/manage.html
+++ b/ckanext/switzerland/templates/subscribe/manage.html
@@ -1,0 +1,77 @@
+{% extends "page.html" %}
+
+{% block styles %}
+  {{ super() }}
+  {% resource 'subscribe/subscribe.css' %}
+{% endblock styles %}
+
+{% block primary %}
+<article class="module">
+  <div class="module-content">
+
+<h1>Manage subscriptions</h1>
+
+<p>Email: {{ email }}</p>
+<p>Subscriptions:</p>
+{% if subscriptions %}
+  <table id="subscriptions">
+    {% for subscription in subscriptions %}
+      <tr>
+        <td>{{ subscription.object_type |capitalize }}</td>
+        <td><a href="{{ subscription.object_link }}">{{ subscription.object_title }}</a></td>
+        <td>
+          {% if not subscription.verified %}Unverified{% endif %}
+        </td>
+        <td>
+          {% if not subscription.verified %}
+            <form method='post' action="{{ h.url_for(controller='ckanext.subscribe.controller:SubscribeController', action='signup') }}" id="subscribe-form" enctype="multipart/form-data" class="form-inline">
+              <!-- (Bootstrap 3) <div class="form-group input-group-sm"> -->
+                <input id="subscribe-email" type="hidden" name="email" value="{{ email }}" />
+                <input id="subscribe-{{ subscription.object_type }}" type="hidden" name="{{ subscription.object_type }}" value="{{ subscription.object_name }}" />
+              <!-- </div> -->
+              <button type="submit" class="btn btn-default" name="save">{{ _('Resend verification email') }}</button>
+            </form>
+          {% endif %}
+        </td>
+        <td>
+          {% if subscription.verified %}
+            {% import 'macros/form.html' as form %}
+            <form method='post' action="{{ h.url_for(controller='ckanext.subscribe.controller:SubscribeController', action='update') }}" id="frequency-form" enctype="multipart/form-data" class="form-inline">
+              <input id="subscribe-code" type="hidden" name="code" value="{{ code }}" />
+              <input id="subscribe-id" type="hidden" name="id" value="{{ subscription.id }}" />
+              {{ form.select('frequency', label=_('Emails are sent'), options=frequency_options, selected=subscription.frequency, error=None) }}
+              <button class="btn btn-primary" type="submit" name="submit" >
+                {{ _('Save') }}
+              </button>
+            </form>
+          {% endif %}
+        </td>
+        <td>
+            <form method='post' action="{{ h.url_for(controller='ckanext.subscribe.controller:SubscribeController', action='unsubscribe') }}" id="unsubscribe-form" enctype="multipart/form-data" class="form-inline">
+              <!-- (Bootstrap 3) <div class="form-group input-group-sm"> -->
+                <input id="unsubscribe-code" type="hidden" name="code" value="{{ code }}" />
+                <input id="unsubscribe-{{ subscription.object_type }}" type="hidden" name="{{ subscription.object_type }}" value="{{ subscription.object_name }}" />
+              <!-- </div> -->
+              <button type="submit" class="btn btn-default" name="save">{{ _('Unsubscribe') }}</button>
+            </form>
+          </td>
+        </tr>
+    {% endfor %}
+  </table>
+
+  <form method='post' action="{{ h.url_for(controller='ckanext.subscribe.controller:SubscribeController', action='unsubscribe_all') }}" id="unsubscribe-all" enctype="multipart/form-data" class="form-inline">
+    <!-- (Bootstrap 3) <div class="form-group input-group-sm"> -->
+      <input id="unsubscribe-code" type="hidden" name="code" value="{{ code }}" />
+    <!-- </div> -->
+    <button type="submit" class="btn btn-default" name="save">{{ _('Unsubscribe all') }}</button>
+  </form>
+
+{% else %}
+  (None)
+{% endif %}
+
+  </div>
+</article>
+{% endblock %}
+
+{% block secondary %}{% endblock %}

--- a/ckanext/switzerland/tests/test_subscription_emails.py
+++ b/ckanext/switzerland/tests/test_subscription_emails.py
@@ -316,14 +316,13 @@ Vielen Dank für Ihre Bestätigung des Datensatz-Abonnements auf opendata.swiss.
     </a>
 </p>''', body_html)
 
-        if code == '':
-            footer_link_text = u'<a href="http://frontend-test.ckan.net/subscribe/manage">Mein Abonnement verwalten</a>'
-        else:
-            footer_link_text = u'<a href="http://frontend-test.ckan.net/subscribe/manage?code={}">Mein Abonnement verwalten</a>'\
-                .format(code)
+        footer_link_text = u''
         if subscription:
-            footer_link_text = u'<a href="http://frontend-test.ckan.net/subscribe/unsubscribe?code=testcode&amp;dataset={dataset_id}">Abonnement löschen</a> | '\
-                                   .format(dataset_id=self.dataset['id']) + footer_link_text
+            footer_link_text = u'<a href="http://frontend-test.ckan.net/subscribe/unsubscribe?code=testcode&amp;dataset={dataset_id}">Abonnement löschen</a> | ' \
+                .format(dataset_id=self.dataset['id'])
+        if code:
+            footer_link_text += u'<a href="http://frontend-test.ckan.net/subscribe/manage?code={}">Mein Abonnement verwalten</a>'\
+                .format(code)
 
         assert_in(footer_link_text, body_html)
 
@@ -335,14 +334,13 @@ CH-2010 Neuchâtel
 www.bfs.admin.ch/ogd
 ''', body_plain_text)
 
-        if code == '':
-            footer_link_text = u'Mein Abonnement verwalten: http://frontend-test.ckan.net/subscribe/manage'
-        else:
-            footer_link_text = u'Mein Abonnement verwalten: http://frontend-test.ckan.net/subscribe/manage?code={}'\
-                .format(code)
+        footer_link_text = u''
         if subscription:
-            footer_link_text = u'Abonnement löschen: http://frontend-test.ckan.net/subscribe/unsubscribe?code=testcode&amp;dataset={dataset_id}\n'\
-                                   .format(dataset_id=self.dataset['id']) + footer_link_text
+            footer_link_text = u'Abonnement löschen: http://frontend-test.ckan.net/subscribe/unsubscribe?code=testcode&amp;dataset={dataset_id}\n' \
+                                   .format(dataset_id=self.dataset['id'])
+        if code:
+            footer_link_text += u'Mein Abonnement verwalten: http://frontend-test.ckan.net/subscribe/manage?code={}' \
+                .format(code)
 
         assert_in(footer_link_text, body_plain_text)
 


### PR DESCRIPTION
This link does not contain an auth code, because the user has not yet verified their subscription and doesn't have one yet. In ckan, the link redirects to a page where the user can request a code be sent to them. On our frontend, we don't have such a page, so the link is useless.