### PR TITLE
feat: transform all datefields that are indexed by Solr

### DIFF
--- a/ckanext/switzerland/helpers/date_helpers.py
+++ b/ckanext/switzerland/helpers/date_helpers.py
@@ -151,9 +151,20 @@ class OGDCHDateValidationException(Exception):
 
 
 def transform_date_for_solr(date_field):
-    """transform datefields for SOLR indexing
-    the timezone information is ignored and the date is stored in SOLR as UTC date.
-    Since all our datetimes are from the same timezone, this approach is preferred."""
+    """Since Solr can only handle dates as isodates with UTC
+    all isodates that are indexed by Solr are transformed in the
+    following way:
+
+    - timezone information is ignored
+    - Z is added at the end of the isodate
+
+    Example:
+    an isodate such as 2022-10-25T15:30:10.330000+02:00 that
+    comes in through harvesting is transformed into
+    2022-10-25T15:30:10.33Z ignoring the timezone information, but it
+    will still be stored in the original isoformat with timezone
+    information in postgres
+    """
     try:
         datetime_without_tz = parse(date_field, ignoretz=True)
         isodate_without_tz = isodate.datetime_isoformat(datetime_without_tz)

--- a/ckanext/switzerland/helpers/date_helpers.py
+++ b/ckanext/switzerland/helpers/date_helpers.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from dateutil.parser import parse
 import logging
 import isodate
 import ckan.plugins.toolkit as tk
@@ -147,3 +148,16 @@ def correct_invalid_empty_date(value):
 
 class OGDCHDateValidationException(Exception):
     pass
+
+
+def transform_date_for_solr(date_field):
+    """transform datefields for SOLR indexing
+    the timezone information is ignored and the date is stored in SOLR as UTC date.
+    Since all our datetimes are from the same timezone, this approach is preferred."""
+    try:
+        datetime_without_tz = parse(date_field, ignoretz=True)
+        isodate_without_tz = isodate.datetime_isoformat(datetime_without_tz)
+        return isodate_without_tz + 'Z'
+    except Exception as e:
+        log.error("Exception {} occured on date transformation of {}".format(e, date_field))
+        return None

--- a/ckanext/switzerland/helpers/date_helpers.py
+++ b/ckanext/switzerland/helpers/date_helpers.py
@@ -170,5 +170,6 @@ def transform_date_for_solr(date_field):
         isodate_without_tz = isodate.datetime_isoformat(datetime_without_tz)
         return isodate_without_tz + 'Z'
     except Exception as e:
-        log.error("Exception {} occured on date transformation of {}".format(e, date_field))
+        log.error("Exception {} occured on date transformation of {}"
+                  .format(e, date_field))
         return None

--- a/ckanext/switzerland/helpers/plugin_utils.py
+++ b/ckanext/switzerland/helpers/plugin_utils.py
@@ -105,6 +105,11 @@ def ogdch_prepare_search_data_for_index(search_data):  # noqa
         resources=validated_dict[u'resources']
     )
     search_data['res_rights'] = [ogdch_term_utils.simplify_terms_of_use(r['rights']) for r in validated_dict[u'resources'] if 'rights' in r.keys()]  # noqa
+    if search_data.get('issued'):
+        search_data['issued'] = ogdch_date_utils.transform_date_for_solr(search_data['issued'])
+
+    if search_data.get('modified'):
+        search_data['modified'] = ogdch_date_utils.transform_date_for_solr(search_data['modified'])
     search_data['res_latest_issued'] = ogdch_date_utils.get_latest_isodate(
         [(r['issued'])
          for r in validated_dict[u'resources']
@@ -115,6 +120,8 @@ def ogdch_prepare_search_data_for_index(search_data):  # noqa
          for r in validated_dict[u'resources']
          if 'modified' in r.keys()]
     )
+    search_data['res_latest_issued'] = ogdch_date_utils.transform_date_for_solr(search_data['res_latest_issued'])
+    search_data['res_latest_modified'] = ogdch_date_utils.transform_date_for_solr(search_data['res_latest_modified'])
     search_data['linked_data'] = ogdch_format_utils.prepare_formats_for_index(
         resources=validated_dict[u'resources'],
         linked_data_only=True
@@ -174,7 +181,8 @@ def ogdch_prepare_search_data_for_index(search_data):  # noqa
         search_data,
         validated_dict
     )
-
+    log.error(search_data['issued'])
+    log.error(search_data['modified'])
     return search_data
 
 

--- a/ckanext/switzerland/tests/test_date_helpers.py
+++ b/ckanext/switzerland/tests/test_date_helpers.py
@@ -1,0 +1,24 @@
+# encoding: utf-8
+
+from nose.tools import assert_equals
+from ckanext.switzerland.helpers.date_helpers import transform_date_for_solr
+
+
+class TestOgdchDateTransformationForSolr(object):
+    def test_transform_of_isodate_without_tz(self):
+        input = "2020-11-05T00:00:00"
+        expected = "2020-11-05T00:00:00Z"
+        output = transform_date_for_solr(input)
+        assert_equals(output, expected)
+
+    def test_transform_of_isodatetime_without_tz(self):
+        input = "2020-11-05T15:30:04"
+        expected = "2020-11-05T15:30:04Z"
+        output = transform_date_for_solr(input)
+        assert_equals(output, expected)
+
+    def test_transform_of_isodatetime_with_tz(self):
+        input = "2022-10-11T15:30:04.359000+02:00"
+        expected = "2022-10-11T15:30:04Z"
+        output = transform_date_for_solr(input)
+        assert_equals(output, expected)


### PR DESCRIPTION
since Solr can only handle dates as isodates with UTC all dates that are indexed by Solr are transformed in the following way: 

for example a date such as `2022-10-25T15:30:10.330000+02:00` that comes in through harvesting is transformed into
`2022-10-25T15:30:10.33Z` ignoring the timezone information

this transformation is only done for Solr, not for the storage in Postgres.