### PR TITLE
fix: env vars are can to be fetched at the load time of the module

### DIFF
--- a/ckanext/switzerland/helpers/mail_helper.py
+++ b/ckanext/switzerland/helpers/mail_helper.py
@@ -5,23 +5,14 @@ from ckan.common import config
 from ckan.lib.base import render_jinja2
 import ckan.lib.mailer as mailer
 
-SITE_TITLE = config.get('ckan.site_title')
-SITE_URL = config.get('ckan.site_url')
-SHOWCASE_ADMIN_EMAIL = config.get(
-    'ckanext.switzerland.showcase_admin_email'
-)
-SHOWCASE_ADMIN_NAME = config.get(
-    'ckanext.switzerland.showcase_admin_name'
-)
-
 log = logging.getLogger(__name__)
 
 
 def get_registration_body(user):
     """set up text for user registration email"""
     extra_vars = {
-        'site_title': SITE_TITLE,
-        'site_url': SITE_URL,
+        'site_title': config.get('ckan.site_title'),
+        'site_url': config.get('ckan.site_url'),
         'user_name': user.get('name'),
         'display_name': user.get('display_name', user['name'])
         }
@@ -33,7 +24,7 @@ def send_registration_email(user):
     """send new users an email at the time of registartion"""
     body = get_registration_body(user)
     extra_vars = {
-        'site_title': SITE_TITLE
+        'site_title': config.get('ckan.site_title')
     }
     subject = render_jinja2('emails/registration_subject.txt', extra_vars)
 
@@ -48,11 +39,14 @@ def send_registration_email(user):
 def send_showcase_email(showcase):
     """send an email when a showcase is created"""
     extra_vars = {
-        'showcase_url': SITE_URL + '/showcase/' + showcase.get('name'),
+        'showcase_url': "{}/showcase/{}".format(
+            config.get('ckan.site_url'),
+            showcase.get('name')
+        )
     }
     mailer.mail_recipient(
-        SHOWCASE_ADMIN_NAME,
-        SHOWCASE_ADMIN_EMAIL,
+        config.get('ckanext.switzerland.showcase_admin_name'),
+        config.get('ckanext.switzerland.showcase_admin_email'),
         render_jinja2('emails/showcase_subject.txt', extra_vars),
         render_jinja2('emails/showcase.txt', extra_vars),
     )


### PR DESCRIPTION
this is because ckanext-envvars runs after ckan and therefore the config settings that are stored in environment variables are not available at the modules load time