### PR TITLE
fix: Link to manage page in notification email, not unsubscribe

### DIFF
--- a/ckanext/switzerland/templates/emails/subscribe_notification.html
+++ b/ckanext/switzerland/templates/emails/subscribe_notification.html
@@ -14,7 +14,7 @@
 {% endif %}
 
 <p>
-    Falls Sie diese Benachrichtigungen nicht mehr erhalten möchten, können Sie Ihr Abo jederzeit <a href="{{ unsubscribe_link }}">beenden</a>.
+    Falls Sie diese Benachrichtigungen nicht mehr erhalten möchten, können Sie Ihr Abo jederzeit <a href="{{ manage_link }}">beenden</a>.
 </p>
 
 <p>
@@ -62,7 +62,7 @@
 {% endif %}
 
 <p>
-    Si vous ne souhaitez plus recevoir ces notifications, vous pouvez vous <a href="{{ unsubscribe_link }}">désabonner</a> à tout moment.
+    Si vous ne souhaitez plus recevoir ces notifications, vous pouvez vous <a href="{{ manage_link }}">désabonner</a> à tout moment.
 </p>
 
 <p>
@@ -110,7 +110,7 @@
 {% endif %}
 
 <p>
-    Se non desidera più ricevere queste notifiche, può <a href="{{ unsubscribe_link }}">disdire</a> l’abbonamento in qualsiasi momento.
+    Se non desidera più ricevere queste notifiche, può <a href="{{ manage_link }}">disdire</a> l’abbonamento in qualsiasi momento.
 </p>
 
 <p>
@@ -161,7 +161,7 @@
 {% endif %}
 
 <p>
-    Should you no longer wish to receive these notifications, you may <a href="{{ unsubscribe_link }}">cancel</a> your subscription at any time.
+    Should you no longer wish to receive these notifications, you may <a href="{{ manage_link }}">cancel</a> your subscription at any time.
 </p>
 
 <p>Best regards,<br/>The OGD office team</p>


### PR DESCRIPTION
We don't have an unsubscribe link to fill in when rendering this email, so we use the manage link instead.