### PR TITLE
fix: rate limit on showcase api calls moved to the api function

### DIFF
--- a/ckanext/switzerland/helpers/request_utils.py
+++ b/ckanext/switzerland/helpers/request_utils.py
@@ -1,10 +1,6 @@
 """utils used for requests"""
 import requests
 import ckan.plugins.toolkit as tk
-from ratelimit import limits, RateLimitException
-from backoff import on_exception, expo
-
-FIVE_MINUTES = 300
 
 
 def get_content_headers(url):
@@ -40,13 +36,3 @@ def request_is_api_request():
     except TypeError:
         # we get here if there is no request (i.e. on the command line)
         return False
-
-
-@on_exception(expo, RateLimitException, max_tries=8)
-@limits(calls=2, period=FIVE_MINUTES)
-def set_call_api_limit(url):
-    response = requests.get(url)
-    if response.status_code != 200:
-        raise Exception('API response: {}'.format(response.status_code))
-
-    return response

--- a/ckanext/switzerland/plugins.py
+++ b/ckanext/switzerland/plugins.py
@@ -507,12 +507,6 @@ class OgdchShowcasePlugin(ShowcasePlugin):
 
     # IDatasetForm
 
-    def new_template(self):
-        base_url = toolkit.request.url
-        response = ogdch_request_utils.set_call_api_limit(base_url)
-        if response:
-            return 'showcase/new.html'
-
     def _modify_package_schema(self, schema):
         schema.update(
             {


### PR DESCRIPTION
the api rate limit was set before we decided to customize the logic that creates a showcase via an api call. The api limit is moved to guard that new function instead of the previously used way to create showcases