### PR TITLE
fix: ogdch_showcase_search: prevent error when a dataset is not found

### DIFF
--- a/ckanext/switzerland/logic.py
+++ b/ckanext/switzerland/logic.py
@@ -303,7 +303,9 @@ def ogdch_showcase_search(context, data_dict):
     result = tk.get_action('package_search')(context, data_dict)
     for showcase in result.get('results', []):
         try:
-            details = tk.get_action('package_show')(context, {'id': showcase.get('name')})
+            details = tk.get_action('package_show')(
+                context, {'id': showcase.get('name')}
+            )
             showcase['num_datasets'] = details.get('num_datasets')
         except Exception as e:
             log.error("Error occured for package_show at {}: {}"

--- a/ckanext/switzerland/logic.py
+++ b/ckanext/switzerland/logic.py
@@ -293,14 +293,21 @@ def ogdch_showcase_search(context, data_dict):
     the number of datasets in each showcase in the output.
     '''
     user = tk.get_action('get_site_user')({'ignore_auth': True}, {})
-    context.update({'user': user['name'], 'for_view': True})
+    context.update({'user': user['name']})
 
-    if data_dict['fq']:
+    if data_dict.get('fq'):
         data_dict['fq'] += ' dataset_type:showcase'
     else:
         data_dict.update({'fq': 'dataset_type:showcase'})
 
     result = tk.get_action('package_search')(context, data_dict)
+    for showcase in result.get('results', []):
+        try:
+            details = tk.get_action('package_show')(context, {'id': showcase.get('name')})
+            showcase['num_datasets'] = details.get('num_datasets')
+        except Exception as e:
+            log.error("Error occured for package_show at {}: {}"
+                      .format(showcase, e))
     if result:
         return result
     else:


### PR DESCRIPTION
if a dataset for a showcase cannot be found, then the logic should none the less return all the showcases instead of crashing with an system error