### PR TITLE
feat: make license field mandatory, make it a select field and offer the four opendata.swiss licenses as options

### DIFF
--- a/ckanext/switzerland/dcat-ap-switzerland_scheming.json
+++ b/ckanext/switzerland/dcat-ap-switzerland_scheming.json
@@ -857,7 +857,7 @@
     },
     {
       "field_name": "license",
-      "form_snippet": null,
+      "preset": "url",
       "required": true,
       "label": {
         "en": "License",

--- a/ckanext/switzerland/dcat-ap-switzerland_scheming.json
+++ b/ckanext/switzerland/dcat-ap-switzerland_scheming.json
@@ -857,7 +857,9 @@
     },
     {
       "field_name": "license",
-      "preset": "url",
+      "preset": "select",
+      "choices_helper": "ogdch_get_license_choices",
+      "validators": "scheming_required",
       "required": true,
       "label": {
         "en": "License",

--- a/ckanext/switzerland/dcat-ap-switzerland_scheming.json
+++ b/ckanext/switzerland/dcat-ap-switzerland_scheming.json
@@ -858,6 +858,7 @@
     {
       "field_name": "license",
       "form_snippet": null,
+      "required": true,
       "label": {
         "en": "License",
         "de": "Lizenz",

--- a/ckanext/switzerland/helpers/dataset_form_helpers.py
+++ b/ckanext/switzerland/helpers/dataset_form_helpers.py
@@ -60,6 +60,18 @@ def ogdch_get_rights_choices(field):
              'value': 'NonCommercialNotAllowed-CommercialWithPermission-ReferenceRequired'}]  # noqa
 
 
+def ogdch_get_license_choices(field):
+    return [{'label': _('Non-commercial Allowed / Commercial Allowed / Reference Not Required'),  # noqa
+             'value': TERMS_OF_USE_OPEN},
+            {'label': _('Non-commercial Allowed / Commercial With Permission Allowed / Reference Not Required'),  # noqa
+             'value': TERMS_OF_USE_ASK},
+            {'label': _('Non-commercial Allowed / Commercial With Permission Allowed / Reference Required'),  # noqa
+             'value': TERMS_OF_USE_BY_ASK},
+            {'label': _('Non-commercial Allowed / Commercial Allowed / Reference Required'),  # noqa
+             'value': TERMS_OF_USE_BY},
+    ]
+
+
 def ogdch_publisher_form_helper(data):
     """
     fills the publisher form snippet either from a previous form entry

--- a/ckanext/switzerland/helpers/dataset_form_helpers.py
+++ b/ckanext/switzerland/helpers/dataset_form_helpers.py
@@ -68,8 +68,7 @@ def ogdch_get_license_choices(field):
             {'label': _('Non-commercial Allowed / Commercial With Permission Allowed / Reference Required'),  # noqa
              'value': TERMS_OF_USE_BY_ASK},
             {'label': _('Non-commercial Allowed / Commercial Allowed / Reference Required'),  # noqa
-             'value': TERMS_OF_USE_BY},
-    ]
+             'value': TERMS_OF_USE_BY}]
 
 
 def ogdch_publisher_form_helper(data):

--- a/ckanext/switzerland/plugins.py
+++ b/ckanext/switzerland/plugins.py
@@ -173,6 +173,7 @@ class OgdchPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'get_localized_value_for_display': ogdch_frontend_helpers.get_localized_value_for_display,  # noqa
             'ogdch_get_accrual_periodicity_choices': ogdch_dataset_form_helpers.ogdch_get_accrual_periodicity_choices,  # noqa
             'ogdch_get_rights_choices': ogdch_dataset_form_helpers.ogdch_get_rights_choices,  # noqa
+            'ogdch_get_license_choices': ogdch_dataset_form_helpers.ogdch_get_license_choices,  # noqa
             'ogdch_publisher_form_helper': ogdch_dataset_form_helpers.ogdch_publisher_form_helper,  # noqa
             'ogdch_contact_points_form_helper': ogdch_dataset_form_helpers.ogdch_contact_points_form_helper,  # noqa
             'ogdch_relations_form_helper': ogdch_dataset_form_helpers.ogdch_relations_form_helper,  # noqa

--- a/ckanext/switzerland/templates/scheming/package/resource_read.html
+++ b/ckanext/switzerland/templates/scheming/package/resource_read.html
@@ -5,7 +5,6 @@
     'description',
     'notes',
     'display_name',
-    'license',
     'media_type',
     ] -%}
 {%- set schema = h.scheming_get_dataset_schema(dataset_type) -%}


### PR DESCRIPTION
For making the dct:license  DCAT-AP CH v2 conformant it needs to be mandatory.