### PR TITLE
fix: Add default values for getting resource docs

### DIFF
--- a/ckanext/switzerland/dcat-ap-switzerland_scheming.json
+++ b/ckanext/switzerland/dcat-ap-switzerland_scheming.json
@@ -619,7 +619,7 @@
       "field_name": "documentation",
       "preset": "multiple_text",
       "display_snippet": "multiple_urls.html",
-      "validators": "scheming_required multiple_text ogdch_validate_list_of_urls",
+      "validators": "scheming_required multiple_text ogdch_validate_formfield_list_of_urls ogdch_validate_list_of_urls",
       "output_validator": "scheming_load_json",
       "fieldgroup": {
         "en": "Documentation",
@@ -956,7 +956,7 @@
       "field_name": "documentation",
       "preset": "multiple_text",
       "display_snippet": "multiple_urls.html",
-      "validators": "scheming_required multiple_text ogdch_validate_list_of_urls",
+      "validators": "scheming_required multiple_text ogdch_validate_formfield_list_of_urls ogdch_validate_list_of_urls",
       "output_validator": "scheming_load_json",
       "fieldgroup": {
         "en": "Documentation",

--- a/ckanext/switzerland/dcat-ap-switzerland_scheming.json
+++ b/ckanext/switzerland/dcat-ap-switzerland_scheming.json
@@ -619,7 +619,8 @@
       "field_name": "documentation",
       "preset": "multiple_text",
       "display_snippet": "multiple_urls.html",
-      "validators": "multiple_text ogdch_validate_list_of_urls",
+      "validators": "scheming_required multiple_text ogdch_validate_list_of_urls",
+      "output_validator": "scheming_load_json",
       "fieldgroup": {
         "en": "Documentation",
         "de": "Dokumentation",
@@ -955,7 +956,8 @@
       "field_name": "documentation",
       "preset": "multiple_text",
       "display_snippet": "multiple_urls.html",
-      "validators": "multiple_text ogdch_validate_list_of_urls",
+      "validators": "scheming_required multiple_text ogdch_validate_list_of_urls",
+      "output_validator": "scheming_load_json",
       "fieldgroup": {
         "en": "Documentation",
         "de": "Dokumentation",

--- a/ckanext/switzerland/dcat-ap-switzerland_scheming.json
+++ b/ckanext/switzerland/dcat-ap-switzerland_scheming.json
@@ -619,7 +619,7 @@
       "field_name": "documentation",
       "preset": "multiple_text",
       "display_snippet": "multiple_urls.html",
-      "validators": "scheming_required multiple_text ogdch_validate_formfield_list_of_urls ogdch_validate_list_of_urls",
+      "validators": "scheming_required multiple_text ogdch_validate_list_of_urls",
       "output_validator": "scheming_load_json",
       "fieldgroup": {
         "en": "Documentation",
@@ -956,7 +956,7 @@
       "field_name": "documentation",
       "preset": "multiple_text",
       "display_snippet": "multiple_urls.html",
-      "validators": "scheming_required multiple_text ogdch_validate_formfield_list_of_urls ogdch_validate_list_of_urls",
+      "validators": "scheming_required multiple_text ogdch_validate_list_of_urls",
       "output_validator": "scheming_load_json",
       "fieldgroup": {
         "en": "Documentation",

--- a/ckanext/switzerland/helpers/dataset_form_helpers.py
+++ b/ckanext/switzerland/helpers/dataset_form_helpers.py
@@ -331,3 +331,18 @@ def ogdch_dataset_title_form_helper(data):
 
 def _get_organization_url(organization_name):
     return ORGANIZATION_URI_BASE + organization_name
+
+
+def ogdch_multiple_text_form_helper(value):
+    """Ensures that the value of a multiple text field is a list.
+
+    If an edited dataset has not been saved because of validation errors, we
+    return to the edit page. Unedited fields are filled in with their saved
+    values, while edited fields are filled with the form data we got from the
+    browser. In this case, if the value of an edited multiple text field is a
+    single string, we just get that string, not a list containing the string.
+    This messes up the multiple_text.html form snippet, so let's prevent it.
+    """
+    if not isinstance(value, list):
+        value = [value]
+    return value

--- a/ckanext/switzerland/helpers/plugin_utils.py
+++ b/ckanext/switzerland/helpers/plugin_utils.py
@@ -310,7 +310,7 @@ def ogdch_map_resource_docs_to_dataset(pkg_dict):
     list, and then deduplicate the list.
     """
     docs = pkg_dict.get("documentation", [])
-    for resource_dict in pkg_dict.get("resources"):
-        docs.extend(resource_dict.get("documentation"))
+    for resource_dict in pkg_dict.get("resources", []):
+        docs.extend(resource_dict.get("documentation", []))
 
     pkg_dict["documentation"] = list(set(docs))

--- a/ckanext/switzerland/helpers/plugin_utils.py
+++ b/ckanext/switzerland/helpers/plugin_utils.py
@@ -309,7 +309,9 @@ def ogdch_map_resource_docs_to_dataset(pkg_dict):
     """Add all resource documentation links to the dataset's documentation
     list, and then deduplicate the list.
     """
-    docs = pkg_dict.get("documentation", [])
+    docs = []
+    if pkg_dict.get("documentation"):
+        docs = pkg_dict.get("documentation")
     for resource_dict in pkg_dict.get("resources", []):
         docs.extend(resource_dict.get("documentation", []))
 

--- a/ckanext/switzerland/helpers/validators.py
+++ b/ckanext/switzerland/helpers/validators.py
@@ -541,22 +541,28 @@ def ogdch_validate_list_of_urls(field, schema):
     def validator(value):
         if value is missing or not value:
             return value
+
+        urls = []
         if type(value) == list:
             urls = value
-        else:
+
+        if not urls:
             try:
                 urls = json.loads(value)
-            except (TypeError, ValueError) as e:
-                raise df.Invalid(
-                    "Error converting %s into a list: %s" % (value, e)
-                )
+            except (TypeError, ValueError):
+                pass
+
+        if not urls:
+            urls = [value]
 
         for url in urls:
             result = urlparse(url)
-            if not result.scheme or not result.netloc or result.netloc == '-':
+            invalid = not result.scheme or \
+                result.scheme not in ["http", "https"] or \
+                not result.netloc
+            if invalid:
                 raise df.Invalid(
-                    "Provided URL %s does not have a valid schema or netloc" %
-                    url
+                    "Provided URL %s is not valid" % url
                 )
 
         return value

--- a/ckanext/switzerland/helpers/validators.py
+++ b/ckanext/switzerland/helpers/validators.py
@@ -344,7 +344,7 @@ def _get_publisher_from_form(extras):
 @scheming_validator
 def ogdch_validate_formfield_contact_points(field, schema):
     """This validator is only used for form validation
-    The data is extracted form the publisher form fields and transformed
+    The data is extracted from the publisher form fields and transformed
     into a form that is expected for database storage:
     u'contact_points': [{u'email': u'tischhauser@ak-strategy.ch',
     u'name': u'tischhauser@ak-strategy.ch'}]

--- a/ckanext/switzerland/helpers/validators.py
+++ b/ckanext/switzerland/helpers/validators.py
@@ -536,29 +536,23 @@ def _jsondata_for_key_is_set(data, key):
 
 @scheming_validator
 def ogdch_validate_list_of_urls(field, schema):
-    """Validates each url in a list or string representation of a list.
+    """Validates each url in a list (stored as json).
     """
     def validator(key, data, errors, context):
         # if there was an error before calling our validator
         # don't bother with our validation
         if errors[key]:
             return
+
         value = data[key]
         if value is missing or not value:
             return value
 
-        urls = None
-        if type(value) == list:
-            urls = value
-
-        if urls is None:
-            try:
-                urls = json.loads(value)
-            except (TypeError, ValueError):
-                pass
-
-        if urls is None:
-            urls = [value]
+        try:
+            urls = json.loads(value)
+        except (TypeError, ValueError):
+            errors[key].append("Error parsing string as JSON: '%s'" % value)
+            return value
 
         # Get rid of empty strings
         urls = [url for url in urls if url]

--- a/ckanext/switzerland/helpers/validators.py
+++ b/ckanext/switzerland/helpers/validators.py
@@ -542,17 +542,17 @@ def ogdch_validate_list_of_urls(field, schema):
         if value is missing or not value:
             return value
 
-        urls = []
+        urls = None
         if type(value) == list:
             urls = value
 
-        if not urls:
+        if urls is None:
             try:
                 urls = json.loads(value)
             except (TypeError, ValueError):
                 pass
 
-        if not urls:
+        if urls is None:
             urls = [value]
 
         for url in urls:

--- a/ckanext/switzerland/helpers/validators.py
+++ b/ckanext/switzerland/helpers/validators.py
@@ -555,6 +555,9 @@ def ogdch_validate_list_of_urls(field, schema):
         if urls is None:
             urls = [value]
 
+        # Get rid of empty strings
+        urls = [url for url in urls if url]
+
         for url in urls:
             result = urlparse(url)
             invalid = not result.scheme or \
@@ -565,19 +568,6 @@ def ogdch_validate_list_of_urls(field, schema):
                     "Provided URL %s is not valid" % url
                 )
 
-        return value
-
-    return validator
-
-
-@scheming_validator
-def ogdch_validate_formfield_list_of_urls(field, schema):
-    def validator(key, data, errors, context):
-        documentation = json.loads(data.get(key, []))
-        results = []
-        for link in documentation:
-            if link:
-                results.append(link)
-        data[key] = json.dumps(results)
+        return urls
 
     return validator

--- a/ckanext/switzerland/helpers/validators.py
+++ b/ckanext/switzerland/helpers/validators.py
@@ -538,7 +538,12 @@ def _jsondata_for_key_is_set(data, key):
 def ogdch_validate_list_of_urls(field, schema):
     """Validates each url in a list or string representation of a list.
     """
-    def validator(value):
+    def validator(key, data, errors, context):
+        # if there was an error before calling our validator
+        # don't bother with our validation
+        if errors[key]:
+            return
+        value = data[key]
         if value is missing or not value:
             return value
 
@@ -564,10 +569,8 @@ def ogdch_validate_list_of_urls(field, schema):
                 result.scheme not in ["http", "https"] or \
                 not result.netloc
             if invalid:
-                raise df.Invalid(
-                    "Provided URL %s is not valid" % url
-                )
+                errors[key].append("Provided URL '%s' is not valid" % url)
 
-        return urls
+        data[key] = json.dumps(urls)
 
     return validator

--- a/ckanext/switzerland/helpers/validators.py
+++ b/ckanext/switzerland/helpers/validators.py
@@ -568,3 +568,16 @@ def ogdch_validate_list_of_urls(field, schema):
         return value
 
     return validator
+
+
+@scheming_validator
+def ogdch_validate_formfield_list_of_urls(field, schema):
+    def validator(key, data, errors, context):
+        documentation = json.loads(data.get(key, []))
+        results = []
+        for link in documentation:
+            if link:
+                results.append(link)
+        data[key] = json.dumps(results)
+
+    return validator

--- a/ckanext/switzerland/plugins.py
+++ b/ckanext/switzerland/plugins.py
@@ -74,6 +74,7 @@ class OgdchPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'ogdch_fluent_tags': ogdch_validators.ogdch_fluent_tags,
             'ogdch_temp_scheming_choices': ogdch_validators.ogdch_temp_scheming_choices,  # noqa
             'ogdch_validate_list_of_urls': ogdch_validators.ogdch_validate_list_of_urls,  # noqa
+            'ogdch_validate_formfield_list_of_urls': ogdch_validators.ogdch_validate_formfield_list_of_urls,  # noqa
         }
 
     # IFacets

--- a/ckanext/switzerland/plugins.py
+++ b/ckanext/switzerland/plugins.py
@@ -194,6 +194,7 @@ class OgdchPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'render_publisher': ogdch_frontend_helpers.render_publisher,
             'ogdch_get_switch_connectome_url': ogdch_backend_helpers.ogdch_get_switch_connectome_url,  # noqa
             'ogdch_get_env': ogdch_backend_helpers.ogdch_get_env,
+            'ogdch_multiple_text_form_helper': ogdch_dataset_form_helpers.ogdch_multiple_text_form_helper,  # noqa
         }
 
     # IRouter

--- a/ckanext/switzerland/plugins.py
+++ b/ckanext/switzerland/plugins.py
@@ -74,7 +74,6 @@ class OgdchPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'ogdch_fluent_tags': ogdch_validators.ogdch_fluent_tags,
             'ogdch_temp_scheming_choices': ogdch_validators.ogdch_temp_scheming_choices,  # noqa
             'ogdch_validate_list_of_urls': ogdch_validators.ogdch_validate_list_of_urls,  # noqa
-            'ogdch_validate_formfield_list_of_urls': ogdch_validators.ogdch_validate_formfield_list_of_urls,  # noqa
         }
 
     # IFacets

--- a/ckanext/switzerland/templates/scheming/form_snippets/multiple_text.html
+++ b/ckanext/switzerland/templates/scheming/form_snippets/multiple_text.html
@@ -16,7 +16,7 @@
   </li>
 {% endmacro %}
 
-{%- set values = data.get(field.field_name, []) or ([''] * field.get('form_blanks', 1)) -%}
+{%- set values = h.ogdch_multiple_text_form_helper(data.get(field.field_name, [])) or ([''] * field.get('form_blanks', 1)) -%}
 
 {% call form.input_block(
   'field-' + field.field_name,

--- a/ckanext/switzerland/templates/scheming/snippets/errors.html
+++ b/ckanext/switzerland/templates/scheming/snippets/errors.html
@@ -41,7 +41,7 @@
                         {%- endif -%}
 
                         {%- snippet sfe_snippet, unprocessed=se_unprocessed,
-                          field=sf, fields=field.repeating_subfileds,
+                          field=sf, fields=field.repeating_subfields,
                           entity_type=entity_type, object_type=object_type -%}
                       {%- endif -%}
 

--- a/ckanext/switzerland/templates/scheming/snippets/errors.html
+++ b/ckanext/switzerland/templates/scheming/snippets/errors.html
@@ -22,7 +22,6 @@
 
         {%- if field.field_name in unprocessed -%}
           {%- set errors = unprocessed.pop(field.field_name) -%}
-          {{ errors }}
           {%- if 'repeating_subfields' in field %}
             {%- for se in errors -%}
               {%- if se -%}
@@ -56,9 +55,11 @@
               {%- endif -%}
             {%- endfor -%}
           {%- else -%}
-            <li data-field-label="{{ field.field_name }}">{{
-              h.scheming_language_text(field.label) }}:
-              {{ errors[0] }}</li>
+            {%- for error in errors -%}
+              <li data-field-label="{{ field.field_name }}">{{
+                h.scheming_language_text(field.label) }}:
+                {{ error }}</li>
+            {%- endfor -%}
           {%- endif -%}
         {%- endif -%}
       {%- endfor -%}

--- a/ckanext/switzerland/templates/scheming/snippets/errors.html
+++ b/ckanext/switzerland/templates/scheming/snippets/errors.html
@@ -1,0 +1,72 @@
+{# shallow copy errors so we can remove processed keys #}
+{%- set unprocessed = errors.copy() -%}
+
+{% block errors_list %}
+<div class="error-explanation alert alert-error">
+  <p>{{ _('The form contains invalid entries:') }}</p>
+  <ul>
+    {% block all_errors %}
+      {%- for field in fields -%}
+        {%- if 'error_snippet' in field -%}
+          {%- set error_snippet = field.error_snippet -%}
+
+          {%- if '/' not in error_snippet -%}
+            {%- set error_snippet = 'scheming/error_snippets/' +
+              error_snippet -%}
+          {%- endif -%}
+
+          {%- snippet error_snippet, unprocessed=unprocessed,
+            field=field, fields=fields,
+            entity_type=entity_type, object_type=object_type -%}
+        {%- endif -%}
+
+        {%- if field.field_name in unprocessed -%}
+          {%- set errors = unprocessed.pop(field.field_name) -%}
+          {{ errors }}
+          {%- if 'repeating_subfields' in field %}
+            {%- for se in errors -%}
+              {%- if se -%}
+                <li data-field-label="{{ field.field_name }}-{{ loop.index }}">{{
+                  h.scheming_language_text(field.repeating_label or field.label) }} {{ loop.index }}:
+                  <ul>
+                    {%- for sf in field.repeating_subfields -%}
+                      {%- set se_unprocessed = se.copy() -%}
+
+                      {%- if 'error_snippet' in sf -%}
+                        {%- set sfe_snippet = sf.error_snippet -%}
+
+                        {%- if '/' not in sfe_snippet -%}
+                          {%- set sfe_snippet = 'scheming/error_snippets/' +
+                            sfe_snippet -%}
+                        {%- endif -%}
+
+                        {%- snippet sfe_snippet, unprocessed=se_unprocessed,
+                          field=sf, fields=field.repeating_subfileds,
+                          entity_type=entity_type, object_type=object_type -%}
+                      {%- endif -%}
+
+                      {%- if sf.field_name in se_unprocessed -%}
+                        <li data-field-label="{{ field.field_name }}-{{ loop.index }}-{{ sf.field_name }}">{{
+                          h.scheming_language_text(sf.label) }}:
+                          {{ se_unprocessed[sf.field_name][0] }}</li>
+                      {%- endif -%}
+                    {%- endfor -%}
+                  </ul>
+                </li>
+              {%- endif -%}
+            {%- endfor -%}
+          {%- else -%}
+            <li data-field-label="{{ field.field_name }}">{{
+              h.scheming_language_text(field.label) }}:
+              {{ errors[0] }}</li>
+          {%- endif -%}
+        {%- endif -%}
+      {%- endfor -%}
+
+      {%- for key, errors in unprocessed.items() | sort -%}
+        <li data-field-label="{{ key }}">{{ _(key) }}: {{ errors[0] }}</li>
+      {%- endfor -%}
+    {% endblock %}
+  </ul>
+</div>
+{% endblock %}

--- a/ckanext/switzerland/tests/test_plugin_utils.py
+++ b/ckanext/switzerland/tests/test_plugin_utils.py
@@ -58,3 +58,56 @@ class TestPluginUtils(unittest.TestCase):
                         sorted(mapped_resource["documentation"]),
                         sorted(resource["documentation"])
                     )
+
+    def test_map_resource_with_no_documentation(self):
+        pkg_dict = {
+            "documentation": [
+                "https://example.com/documentation-dataset-1",
+                "https://example.com/documentation-dataset-2"
+            ],
+            "resources": [
+                {
+                    "id": "resource-1",
+                    "documentation": []
+                },
+                {
+                    "id": "resource-2"
+                }
+            ]
+        }
+        mapped_pkg = pkg_dict
+        ogdch_plugin_utils.ogdch_map_resource_docs_to_dataset(mapped_pkg)
+
+        self.assertEquals(len(mapped_pkg["documentation"]), 2)
+
+    def test_map_dataset_with_no_documentation(self):
+        pkg_dict = {
+            "resources": [
+                {
+                    "id": "resource-1",
+                    "documentation": [
+                        "https://example.com/documentation-resource-1",
+                        "https://example.com/documentation-dataset-1",
+                    ]
+                },
+                {
+                    "id": "resource-2",
+                    "documentation": [
+                        "https://example.com/documentation-resource-2",
+                        "https://example.com/documentation-dataset-1",
+                    ]
+                }
+            ]
+        }
+        mapped_pkg = pkg_dict
+        ogdch_plugin_utils.ogdch_map_resource_docs_to_dataset(mapped_pkg)
+
+        self.assertEquals(len(mapped_pkg["documentation"]), 3)
+        self.assertEquals(
+            sorted(mapped_pkg["documentation"]),
+            [
+                "https://example.com/documentation-dataset-1",
+                "https://example.com/documentation-resource-1",
+                "https://example.com/documentation-resource-2",
+            ]
+        )

--- a/ckanext/switzerland/tests/test_validators.py
+++ b/ckanext/switzerland/tests/test_validators.py
@@ -1,4 +1,6 @@
 # encoding: utf-8
+import json
+
 from ckan.lib.navl.dictization_functions import Invalid
 from ckan.plugins.toolkit import get_validator
 from nose.tools import assert_equals, assert_raises
@@ -13,36 +15,30 @@ class TestOgdchUrlListValidator(object):
             'field', {}
         )
 
-    def test_validate_url_list(self):
-        urls = ["https://example.com/1", "http://example.com/2"]
-        # We pass in dummy values for field and schema here, because we just
-        # want to get the inner validation function, and that does not use
-        # either of these parameters.
-        assert_equals(urls, self.validator(urls))
-
     def test_validate_url_list_string(self):
-        urls = '["https://example.com/1", "http://example.com/2"]'
-        assert_equals(urls, self.validator(urls))
+        value = '["https://example.com/1", "http://example.com/2"]'
+        key = "documentation"
+        data = {
+            key: value,
+        }
+        errors = {
+            key: [],
+        }
+        self.validator(key, data, errors, {})
 
-    def test_validate_single_url(self):
-        url = "http://example.com/foo"
+        assert_equals(value, data[key])
+        assert_equals([], errors[key])
 
-        with assert_raises(Invalid) as cm:
-            self.validator(url)
+    def test_validate_url_list_string_with_invalid_url(self):
+        value = '["http://example.com/foo", "foobar"]'
+        key = "documentation"
+        data = {
+            key: value,
+        }
+        errors = {
+            key: [],
+        }
+        self.validator(key, data, errors, {})
 
-        assert_equals(
-            cm.exception.error,
-            "Error converting http://example.com/foo into a list: "
-            "No JSON object could be decoded"
-        )
-
-    def test_validate_invalid_url(self):
-        urls = ["http://example.com/foo", "foobar"]
-
-        with assert_raises(Invalid) as cm:
-            self.validator(urls)
-
-        assert_equals(
-            cm.exception.error,
-            "Provided URL foobar does not have a valid schema or netloc"
-        )
+        assert_equals(value, data[key])
+        assert_equals([u"Provided URL 'foobar' is not valid"], errors[key])


### PR DESCRIPTION
- Fix bug where we get a 500 on dataset pages with `None` value for `documentation` field
- Fix bug where adding a single, invalid documentation link adds a link for each letter of that invalid link
- Allow removing documentation links in the CKAN GUI
- Validate that links have a valid url scheme (https or http)
- Override `error.html` template from ckanext-scheming to fix typo, plus display all errors on a field at once (so if you have three invalid links, you can see at once that all three are invalid)