### PR TITLE
fix: set rights value while updateing resource if license not set

### DIFF
--- a/ckanext/switzerland/dcat-ap-switzerland_scheming.json
+++ b/ckanext/switzerland/dcat-ap-switzerland_scheming.json
@@ -895,7 +895,7 @@
       "field_name": "license",
       "preset": "select",
       "choices_helper": "ogdch_get_license_choices",
-      "validators": "scheming_required",
+      "validators": "ogdch_license_required",
       "required": true,
       "label": {
         "en": "License",

--- a/ckanext/switzerland/helpers/validators.py
+++ b/ckanext/switzerland/helpers/validators.py
@@ -210,6 +210,16 @@ def ogdch_language(field, schema):
 
 
 @scheming_validator
+def ogdch_license_required(field, schema):
+    def validator(key, data, errors, context):
+        value = data[key]
+        if value is missing or value is None:
+            rights = data.get(key[:-1] + ('rights',))
+            data[key] = rights
+    return validator
+
+
+@scheming_validator
 def ogdch_unique_identifier(field, schema):
     def validator(key, data, errors, context):
         identifier = data.get(key[:-1] + ('identifier',))

--- a/ckanext/switzerland/plugins.py
+++ b/ckanext/switzerland/plugins.py
@@ -64,6 +64,7 @@ class OgdchPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'multilingual_text_output': ogdch_validators.multilingual_text_output, # noqa
             'harvest_list_of_dicts': ogdch_validators.harvest_list_of_dicts,
             'ogdch_language': ogdch_validators.ogdch_language,
+            'ogdch_license_required': ogdch_validators.ogdch_license_required,
             'ogdch_unique_identifier': ogdch_validators.ogdch_unique_identifier, # noqa
             'ogdch_required_in_one_language': ogdch_validators.ogdch_required_in_one_language, # noqa
             'ogdch_validate_formfield_publisher': ogdch_validators.ogdch_validate_formfield_publisher,  # noqa


### PR DESCRIPTION
Since license is mandatory for dcat ap v2 we need to set the value of the rights field for the license field, if the license is not set for avoidung errors while updateing a resource via the ckan admin.