### PR TITLE
fix: Handle multitext strings that get converted to integers

### DIFF
--- a/ckanext/switzerland/helpers/localize_utils.py
+++ b/ckanext/switzerland/helpers/localize_utils.py
@@ -26,6 +26,13 @@ def parse_json(value, default_value=None):
     except (ValueError, TypeError, AttributeError):
         if default_value is not None:
             return default_value
+
+        # The json may already have been parsed and we have the value for the
+        # language already.
+        if isinstance(value, int):
+            # If the value is a number, it has been converted into an int - but
+            # we want a string here.
+            return str(value)
         return value
 
 

--- a/ckanext/switzerland/helpers/validators.py
+++ b/ckanext/switzerland/helpers/validators.py
@@ -67,6 +67,8 @@ def multilingual_text_output(value):
     Return stored json representation as a multilingual dict, if
     value is already a dict just pass it through.
     """
+    if isinstance(value, int):
+        return str(value)
     if isinstance(value, dict):
         return value
     return parse_json(value)

--- a/ckanext/switzerland/helpers/validators.py
+++ b/ckanext/switzerland/helpers/validators.py
@@ -63,12 +63,9 @@ def multiple_text(field, schema):
 
 
 def multilingual_text_output(value):
-    """
-    Return stored json representation as a multilingual dict, if
+    """Return stored json representation as a multilingual dict. If
     value is already a dict just pass it through.
     """
-    if isinstance(value, int):
-        return str(value)
     if isinstance(value, dict):
         return value
     return parse_json(value)

--- a/ckanext/switzerland/tests/test_helpers_localize.py
+++ b/ckanext/switzerland/tests/test_helpers_localize.py
@@ -32,6 +32,7 @@ organizations = [{'children': [],
 
 organization_title = u'{"fr": "Swisstopo FR", "de": "Swisstopo DE", "en": "Swisstopo EN", "it": "Swisstopo IT"}'  # noqa
 
+
 class TestHelpers(unittest.TestCase):
     def test_get_localized_value_from_dict(self):
         lang_dict = {
@@ -55,18 +56,21 @@ class TestHelpers(unittest.TestCase):
         self.assertEquals(lang_dict['de'], result)
 
     def test_parse_json_error_and_default_value(self):
-        """if an error occurs the value should be returned as is"""
+        """if an error occurs the default value should be returned"""
         value = u"{Hallo"
         default_value = "Hello world"
         self.assertEqual(ogdch_localize_utils.parse_json(value, default_value=default_value), default_value)
 
     def test_parse_json_with_error(self):
-        """if an error occurs the default value should be returned"""
+        """if an error occurs the value should be returned as is"""
         value = u"{Hallo"
         self.assertEqual(ogdch_localize_utils.parse_json(value), value)
 
     def test_parse_json_without_error(self):
-        """if an error occurs the default value should be returned"""
         value = '{"de": "Hallo", "it": "okay"}'
         value_as_dict = {"de": "Hallo", "it":"okay"}
         self.assertEqual(ogdch_localize_utils.parse_json(value), value_as_dict)
+
+    def test_parse_json_with_int_value(self):
+        value = 6
+        self.assertEqual(ogdch_localize_utils.parse_json(value), str(value))


### PR DESCRIPTION
E.g. some resources have the name '0' in one language, which gets saved as a string value in a localised dict, but converted to an integer on output. We need to cast that integer value back to a string to display it.