### PR TITLE
Disable manual rights change for the resources

### DIFF
--- a/ckanext/switzerland/dcat-ap-switzerland_scheming.json
+++ b/ckanext/switzerland/dcat-ap-switzerland_scheming.json
@@ -918,24 +918,6 @@
       }
     },
     {
-      "field_name": "rights",
-      "preset": "select",
-      "choices_helper": "ogdch_get_rights_choices",
-      "validators": "scheming_required",
-      "label": {
-        "en": "Terms of use",
-        "de": "Nutzungsbedingungen",
-        "fr": "Conditions d'utilisation",
-        "it": "Condizioni d'uso"
-      },
-      "help_text": {
-        "de": "Wichtig: Alle Nutzungsbedingungen, welche nicht mit einem Stern (*) markiert sind, gelten als 'Closed Data'.",
-        "en": "Important: All terms of use that are not marked with an asterisk (*) are considered 'Closed Data'.",
-        "fr": "Important : Toutes les conditions d'utilisation qui ne sont pas marquées d'un astérisque (*) sont considérées comme des \"données fermées\".",
-        "it": "Importante: Tutte le condizioni d'uso che non sono contrassegnate da un asterisco (*) sono considerate \"Dati chiusi\"."
-      }
-    },
-    {
       "field_name": "license",
       "preset": "select",
       "choices_helper": "ogdch_get_license_choices",


### PR DESCRIPTION
Since rights are deprecated property now, we are not allowing users to change it manually.
Instead they will use license  