### PR TITLE
Display license instead of rights 

### DIFF
--- a/ckanext/switzerland/dcat-ap-switzerland_scheming.json
+++ b/ckanext/switzerland/dcat-ap-switzerland_scheming.json
@@ -918,34 +918,16 @@
       }
     },
     {
-      "field_name": "rights",
-      "preset": "select",
-      "choices_helper": "ogdch_get_rights_choices",
-      "validators": "scheming_required",
-      "label": {
-        "en": "Terms of use",
-        "de": "Nutzungsbedingungen",
-        "fr": "Conditions d'utilisation",
-        "it": "Condizioni d'uso"
-      },
-      "help_text": {
-        "de": "Wichtig: Alle Nutzungsbedingungen, welche nicht mit einem Stern (*) markiert sind, gelten als 'Closed Data'.",
-        "en": "Important: All terms of use that are not marked with an asterisk (*) are considered 'Closed Data'.",
-        "fr": "Important : Toutes les conditions d'utilisation qui ne sont pas marquées d'un astérisque (*) sont considérées comme des \"données fermées\".",
-        "it": "Importante: Tutte le condizioni d'uso che non sono contrassegnate da un asterisco (*) sono considerate \"Dati chiusi\"."
-      }
-    },
-    {
       "field_name": "license",
       "preset": "select",
       "choices_helper": "ogdch_get_license_choices",
       "validators": "ogdch_license_required",
       "required": true,
       "label": {
-        "en": "License",
-        "de": "Lizenz",
-        "fr": "Licence",
-        "it": "Licenza"
+        "en": "License (Terms of use)",
+        "de": "Lizenz (Nutzungsbedingungen)",
+        "fr": "Licence (Conditions d'utilisation)",
+        "it": "Licenza (Condizioni d'uso)"
       }
     },
     {

--- a/ckanext/switzerland/helpers/dataset_form_helpers.py
+++ b/ckanext/switzerland/helpers/dataset_form_helpers.py
@@ -33,33 +33,6 @@ def ogdch_get_accrual_periodicity_choices(field):
     return map
 
 
-def ogdch_get_rights_choices(field):
-    return [{'label': _('* Non-commercial Allowed / Commercial Allowed / Reference Not Required'),  # noqa
-             'value': TERMS_OF_USE_OPEN},
-            {'label': _('* Non-commercial Allowed / Commercial With Permission Allowed / Reference Not Required'),  # noqa
-             'value': TERMS_OF_USE_ASK},
-            {'label': _('* Non-commercial Allowed / Commercial With Permission Allowed / Reference Required'),  # noqa
-             'value': TERMS_OF_USE_BY_ASK},
-            {'label': _('* Non-commercial Allowed / Commercial Allowed / Reference Required'),  # noqa
-             'value': TERMS_OF_USE_BY},
-            {'label':_('Non-commercial Allowed / Commercial Not Allowed / Reference Not Required'),  # noqa
-             'value': 'NonCommercialAllowed-CommercialNotAllowed-ReferenceNotRequired'},  # noqa
-            {'label':_('Non-commercial Allowed / Commercial Not Allowed / Reference Required'),  # noqa
-             'value': 'NonCommercialAllowed-CommercialNotAllowed-ReferenceRequired'},  # noqa
-            {'label': _('Non-commercial Not Allowed / Commercial Not Allowed / Reference Not Required'),  # noqa
-             'value': 'NonCommercialNotAllowed-CommercialNotAllowed-ReferenceNotRequired'},  # noqa
-            {'label': _('Non-commercial Not Allowed / Commercial Not Allowed / Reference Required'),  # noqa
-             'value': 'NonCommercialNotAllowed-CommercialNotAllowed-ReferenceRequired'},  # noqa
-            {'label': _('Non-commercial Not Allowed / Commercial Allowed / Reference Not Required'),  # noqa
-             'value': 'NonCommercialNotAllowed-CommercialAllowed-ReferenceNotRequired'},  # noqa
-            {'label': _('Non-commercial Not Allowed / Commercial Allowed / Reference Required'),  # noqa
-             'value': 'NonCommercialNotAllowed-CommercialAllowed-ReferenceRequired'},  # noqa
-            {'label': _('Non-commercial Not Allowed / Commercial With Permission Allowed / Reference Not Required'),  # noqa
-             'value': 'NonCommercialNotAllowed-CommercialWithPermission-ReferenceNotRequired'},  # noqa
-            {'label': _('Non-commercial Not Allowed / Commercial With Permission Allowed / Reference Required'),  # noqa
-             'value': 'NonCommercialNotAllowed-CommercialWithPermission-ReferenceRequired'}]  # noqa
-
-
 def ogdch_get_license_choices(field):
     return [{'label': _('Non-commercial Allowed / Commercial Allowed / Reference Not Required'),  # noqa
              'value': TERMS_OF_USE_OPEN},

--- a/ckanext/switzerland/helpers/frontend_helpers.py
+++ b/ckanext/switzerland/helpers/frontend_helpers.py
@@ -184,7 +184,7 @@ def get_terms_of_use_url(terms_of_use):
 def get_dataset_terms_of_use(pkg):
     rights = logic.get_action('ogdch_dataset_terms_of_use')(
         {}, {'id': pkg['id']})
-    return rights['dataset_rights']
+    return rights['dataset_license']
 
 
 def get_dataset_by_identifier(identifier):

--- a/ckanext/switzerland/helpers/plugin_utils.py
+++ b/ckanext/switzerland/helpers/plugin_utils.py
@@ -80,7 +80,11 @@ def ogdch_prepare_search_data_for_index(search_data):  # noqa
     search_data['res_format'] = ogdch_format_utils.prepare_formats_for_index(
         resources=validated_dict[u'resources']
     )
-    search_data['res_license'] = [ogdch_term_utils.simplify_terms_of_use(r['license']) for r in validated_dict[u'resources'] if 'license' in r.keys()]  # noqa
+    search_data['res_license'] = [
+        ogdch_term_utils.simplify_terms_of_use(r['license'])
+        for r in validated_dict[u'resources']
+        if 'license' in r.keys()
+    ]
     search_data['res_latest_issued'] = ogdch_date_utils.get_latest_isodate(
         [(r['issued'])
          for r in validated_dict[u'resources']

--- a/ckanext/switzerland/helpers/plugin_utils.py
+++ b/ckanext/switzerland/helpers/plugin_utils.py
@@ -42,7 +42,7 @@ def _prepare_suggest_context(search_data, pkg_dict):
     search_data['suggest_tags'].extend([clean_suggestion(t) for t in search_data.get('keywords_it', [])])  # noqa
     search_data['suggest_tags'].extend([clean_suggestion(t) for t in search_data.get('keywords_en', [])])  # noqa
 
-    search_data['suggest_res_rights'] = [clean_suggestion(t) for t in search_data['res_rights']]  # noqa
+    search_data['suggest_res_license'] = [clean_suggestion(t) for t in search_data['res_license']]  # noqa
     search_data['suggest_res_format'] = [clean_suggestion(t) for t in search_data['res_format']]  # noqa
 
     return search_data
@@ -80,7 +80,7 @@ def ogdch_prepare_search_data_for_index(search_data):  # noqa
     search_data['res_format'] = ogdch_format_utils.prepare_formats_for_index(
         resources=validated_dict[u'resources']
     )
-    search_data['res_rights'] = [ogdch_term_utils.simplify_terms_of_use(r['rights']) for r in validated_dict[u'resources'] if 'rights' in r.keys()]  # noqa
+    search_data['res_license'] = [ogdch_term_utils.simplify_terms_of_use(r['license']) for r in validated_dict[u'resources'] if 'license' in r.keys()]  # noqa
     search_data['res_latest_issued'] = ogdch_date_utils.get_latest_isodate(
         [(r['issued'])
          for r in validated_dict[u'resources']

--- a/ckanext/switzerland/helpers/terms_of_use_utils.py
+++ b/ckanext/switzerland/helpers/terms_of_use_utils.py
@@ -19,4 +19,4 @@ def simplify_terms_of_use(term_id):
 
     if term_id in terms:
         return term_id
-    return 'ClosedData'
+    return TERMS_OF_USE_CLOSED

--- a/ckanext/switzerland/helpers/validators.py
+++ b/ckanext/switzerland/helpers/validators.py
@@ -230,7 +230,7 @@ def ogdch_license_required(field, schema):
 
         log.debug("Resource % has neither license nor rights")
         errors[key].append(
-            "Distributions must have either 'rights' or 'license'"
+            "Distributions must have 'license' property"
         )
         data[key] = ''
     return validator

--- a/ckanext/switzerland/logic.py
+++ b/ckanext/switzerland/logic.py
@@ -205,7 +205,6 @@ def ogdch_dataset_terms_of_use(context, data_dict):
                 continue
             if terms.index(res['license']) > terms.index(least_open):
                 least_open = res['license']
-    log.info("HEREREEEESS")
     if least_open is None:
         least_open = 'ClosedData'
 

--- a/ckanext/switzerland/logic.py
+++ b/ckanext/switzerland/logic.py
@@ -177,8 +177,10 @@ def ogdch_dataset_terms_of_use(context, data_dict):
     Returns the terms of use for the requested dataset.
 
     By definition the terms of use of a dataset corresponds
-    to the least open rights statement of all distributions of
-    the dataset
+    to the least open license statement of all distributions of
+    the dataset.
+    Important : The property dct:license is now required
+    for the terms of use instead of dct:rights
     '''
     terms = [
         'NonCommercialAllowed-CommercialAllowed-ReferenceNotRequired',
@@ -194,21 +196,21 @@ def ogdch_dataset_terms_of_use(context, data_dict):
 
     least_open = None
     for res in pkg['resources']:
-        if 'rights' in res:
-            if res['rights'] not in terms:
+        if 'license' in res:
+            if res['license'] not in terms:
                 least_open = 'ClosedData'
                 break
             if least_open is None:
-                least_open = res['rights']
+                least_open = res['license']
                 continue
-            if terms.index(res['rights']) > terms.index(least_open):
-                least_open = res['rights']
-
+            if terms.index(res['license']) > terms.index(least_open):
+                least_open = res['license']
+    log.info("HEREREEEESS")
     if least_open is None:
         least_open = 'ClosedData'
 
     return {
-        'dataset_rights': least_open
+        'dataset_license': least_open
     }
 
 

--- a/ckanext/switzerland/plugins.py
+++ b/ckanext/switzerland/plugins.py
@@ -91,7 +91,7 @@ class OgdchPlugin(plugins.SingletonPlugin, DefaultTranslation):
         facets_dict['keywords_' + lang_code] = plugins.toolkit._('Keywords')
         facets_dict['organization'] = plugins.toolkit._('Organizations')
         facets_dict['political_level'] = plugins.toolkit._('Political levels')
-        facets_dict['res_rights'] = plugins.toolkit._('Terms of use')
+        facets_dict['res_license'] = plugins.toolkit._('Terms of use')
         facets_dict['res_format'] = plugins.toolkit._('Formats')
         return facets_dict
 
@@ -104,7 +104,7 @@ class OgdchPlugin(plugins.SingletonPlugin, DefaultTranslation):
         facets_dict['keywords_' + lang_code] = plugins.toolkit._('Keywords')
         facets_dict['organization'] = plugins.toolkit._('Organizations')
         facets_dict['political_level'] = plugins.toolkit._('Political levels')
-        facets_dict['res_rights'] = plugins.toolkit._('Terms of use')
+        facets_dict['res_license'] = plugins.toolkit._('Terms of use')
         facets_dict['res_format'] = plugins.toolkit._('Formats')
         return facets_dict
 
@@ -117,7 +117,7 @@ class OgdchPlugin(plugins.SingletonPlugin, DefaultTranslation):
         facets_dict['private'] = plugins.toolkit._('Draft')
         facets_dict['groups'] = plugins.toolkit._('Categories')
         facets_dict['keywords_' + lang_code] = plugins.toolkit._('Keywords')
-        facets_dict['res_rights'] = plugins.toolkit._('Terms of use')
+        facets_dict['res_license'] = plugins.toolkit._('Terms of use')
         facets_dict['res_format'] = plugins.toolkit._('Formats')
         return facets_dict
 
@@ -179,7 +179,6 @@ class OgdchPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'get_localized_value_from_json': ogdch_localize_utils.get_localized_value_from_json, # noqa
             'get_localized_value_for_display': ogdch_frontend_helpers.get_localized_value_for_display,  # noqa
             'ogdch_get_accrual_periodicity_choices': ogdch_dataset_form_helpers.ogdch_get_accrual_periodicity_choices,  # noqa
-            'ogdch_get_rights_choices': ogdch_dataset_form_helpers.ogdch_get_rights_choices,  # noqa
             'ogdch_get_license_choices': ogdch_dataset_form_helpers.ogdch_get_license_choices,  # noqa
             'ogdch_publisher_form_helper': ogdch_dataset_form_helpers.ogdch_publisher_form_helper,  # noqa
             'ogdch_contact_points_form_helper': ogdch_dataset_form_helpers.ogdch_contact_points_form_helper,  # noqa

--- a/ckanext/switzerland/tests/test_validators.py
+++ b/ckanext/switzerland/tests/test_validators.py
@@ -170,7 +170,7 @@ class TestOgdchLicenseRequiredValidator(object):
 
         assert_equals('', data[key])
         assert_equals(
-            ["Distributions must have either 'rights' or 'license'"],
+            ["Distributions must have 'license' property"],
             errors[key]
         )
 

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -278,7 +278,7 @@ schema. In this case the version should be set to the next CKAN version number.
     <field name="res_description_de" type="text_de" indexed="true" stored="true" multiValued="true"/>
     <field name="res_description_it" type="text_it" indexed="true" stored="true" multiValued="true"/>
     <field name="res_format" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="res_rights" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="res_license" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="res_url" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="res_type" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="res_latest_issued" type="date" indexed="true" stored="true" multiValued="false"/>
@@ -331,7 +331,7 @@ schema. In this case the version should be set to the next CKAN version number.
     <field name="suggest_groups" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="suggest_tags" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="suggest_organization" type="string" indexed="true" stored="true" multiValued="false"/>
-    <field name="suggest_res_rights" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="suggest_res_license" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="suggest_res_format" type="string" indexed="true" stored="true" multiValued="true"/>
 
     <!-- Multilingual -->
@@ -445,7 +445,7 @@ schema. In this case the version should be set to the next CKAN version number.
 <copyField source="suggest_tags" dest="suggest_context"/>
 <copyField source="suggest_organization" dest="suggest_context"/>
 <copyField source="political_level" dest="suggest_context"/>
-<copyField source="suggest_res_rights" dest="suggest_context"/>
+<copyField source="suggest_res_license" dest="suggest_context"/>
 <copyField source="suggest_res_format" dest="suggest_context"/>
 
 <copyField source="title_en" dest="suggest_en"/>


### PR DESCRIPTION
1) for the manual corrections of the dataset: show only license 
2) as a "term of use" the licenses should be used to calculate datasets in each license category and display in the  facets